### PR TITLE
Enable session monitoring by non-superuser role

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ into the docker container under /var/logs/supervisor/
 ```
 create role pgwatch2 with login password 'secret';
 ```
+* Define the helper function to enable the monitoring of sessions, blocking locks, etc by the `pgwatch2` login defined above, if using a superuser login (not recommended) you can skip this step, just ensure that you check the `Is superuser?` check box when configuring Databases
+```
+psql -h mydb.com -U superuser -f pgwatch2/sql/metric_fetching_helpers/stat_activity_wrapper.sql mydb
+```
+
 * Additionally for extra insights ("Stat statements" dashboard and CPU load) it's also recommended to install the pg_stat_statement
 extension (Postgres 9.4+ needed to be useful for pgwatch2) and the PL/Python language. The latter one though is usually disabled by DB-as-a-service providers for security reasons.
 
@@ -110,8 +115,8 @@ CREATE EXTENSION plpythonu;
 
 Now also install the wrapper functions (under superuser role) for enabling "Stat statement" and CPU load info fetching for non-superusers
 ```
-psql -h mydb.com -U superuser -f pgwatch2/sql/metrics_fetching_helpers/stat_statements_wrapper.sql mydb
-psql -h mydb.com -U superuser -f pgwatch2/sql/metrics_fetching_helpers/cpu_load_plpythonu.sql mydb
+psql -h mydb.com -U superuser -f pgwatch2/sql/metric_fetching_helpers/stat_statements_wrapper.sql mydb
+psql -h mydb.com -U superuser -f pgwatch2/sql/metric_fetching_helpers/cpu_load_plpythonu.sql mydb
 ```
 
 # Screenshot of the "DB overview" dashboard

--- a/pgwatch2/sql/datastore_setup/metric_definitions.sql
+++ b/pgwatch2/sql/datastore_setup/metric_definitions.sql
@@ -6,7 +6,7 @@ values (
 9.0,
 $sql$
 with sa_snapshot as (
-  select * from pg_stat_activity where pid != pg_backend_pid() and not query like 'autovacuum:%' and datname = current_database()
+  select * from get_stat_activity() where pid != pg_backend_pid() and not query like 'autovacuum:%' and datname = current_database()
 )
 select
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
@@ -30,7 +30,7 @@ values (
 9.6,
 $sql$
 with sa_snapshot as (
-  select * from pg_stat_activity where pid != pg_backend_pid() and not query like 'autovacuum:%' and datname = current_database()
+  select * from get_stat_activity() where pid != pg_backend_pid() and not query like 'autovacuum:%' and datname = current_database()
 )
 select
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
@@ -54,7 +54,7 @@ values (
 10,
 $sql$
 with sa_snapshot as (
-  select * from pg_stat_activity
+  select * from get_stat_activity()
   where pid != pg_backend_pid()
   and datname = current_database()
   and backend_type = 'client backend'
@@ -191,7 +191,7 @@ WITH q_stat_tables AS (
   AND c.relpages > (1e7 / 8)    -- >10MB
 ),
 q_stat_activity AS (
-  SELECT * FROM pg_stat_activity WHERE pid != pg_backend_pid() AND datname = current_database()
+  SELECT * FROM get_stat_activity() WHERE pid != pg_backend_pid() AND datname = current_database()
 )
 SELECT
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
@@ -236,7 +236,7 @@ WITH q_stat_tables AS (
   AND c.relpages > (1e7 / 8)    -- >10MB
 ),
 q_stat_activity AS (
-  SELECT * FROM pg_stat_activity WHERE pid != pg_backend_pid() AND datname = current_database()
+  SELECT * FROM get_stat_activity() WHERE pid != pg_backend_pid() AND datname = current_database()
 )
 SELECT
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
@@ -281,7 +281,7 @@ WITH q_stat_tables AS (
   AND c.relpages > (1e7 / 8)    -- >10MB
 ),
 q_stat_activity AS (
-  SELECT * FROM pg_stat_activity WHERE pid != pg_backend_pid() AND datname = current_database()
+  SELECT * FROM get_stat_activity() WHERE pid != pg_backend_pid() AND datname = current_database()
 )
 SELECT
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
@@ -640,7 +640,7 @@ SELECT
   count(*)
 FROM
   pg_stat_ssl AS s,
-  pg_stat_activity AS a
+  get_stat_activity() AS a
 WHERE
   a.pid = s.pid
   AND a.datname = current_database()
@@ -747,7 +747,7 @@ SELECT
 FROM
     pg_catalog.pg_locks AS waiting
 JOIN
-    pg_catalog.pg_stat_activity AS waiting_stm
+    public.get_stat_activity() AS waiting_stm
     ON (
         waiting_stm.pid = waiting.pid
     )
@@ -761,7 +761,7 @@ JOIN
         OR waiting.transactionid = other.transactionid
     )
 JOIN
-    pg_catalog.pg_stat_activity AS other_stm
+    public.get_stat_activity() AS other_stm
     ON (
         other_stm.pid = other.pid
     )
@@ -1007,6 +1007,28 @@ BEGIN
   END IF;
 END;
 $OUTER$;
+$sql$,
+'for internal usage - when connecting user is marked as superuser then the daemon will automatically try to create the needed helpers on the monitored db',
+true
+);
+
+/* Stored procedure wrapper for pg_stat_activity - needed for non-superuser to view session state */
+insert into pgwatch2.metric(m_name, m_pg_version_from, m_sql, m_comment, m_is_helper)
+values (
+'get_stat_activity',
+9.0,
+$sql$
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.get_stat_activity() RETURNS SETOF pg_stat_activity AS
+$$
+  select * from pg_stat_activity
+$$ LANGUAGE sql VOLATILE SECURITY DEFINER;
+
+REVOKE EXECUTE ON FUNCTION public.get_stat_activity() FROM PUBLIC;
+COMMENT ON FUNCTION public.get_stat_activity() IS ''created for pgwatch2'';
+
+COMMIT;
 $sql$,
 'for internal usage - when connecting user is marked as superuser then the daemon will automatically try to create the needed helpers on the monitored db',
 true

--- a/pgwatch2/sql/metric_fetching_helpers/stat_activity_wrapper.sql
+++ b/pgwatch2/sql/metric_fetching_helpers/stat_activity_wrapper.sql
@@ -1,0 +1,15 @@
+/*
+A wrapper around pg_stat_activity to enable session, blocking lock, etc monitoring
+by the non-superuser pgwatch2 role.
+*/
+
+Assumes a role has been created named pgwatch2
+
+CREATE OR REPLACE FUNCTION public.get_stat_activity() RETURNS SETOF pg_stat_activity AS
+$$
+  select * from pg_stat_activity;
+$$ LANGUAGE sql VOLATILE SECURITY DEFINER;
+
+REVOKE EXECUTE ON FUNCTION public.get_stat_activity() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_stat_activity() TO pgwatch2;
+COMMENT ON FUNCTION public.get_stat_activity() is 'created for pgwatch2';

--- a/pgwatch2/sql/metric_fetching_helpers/stat_statements_wrapper.sql
+++ b/pgwatch2/sql/metric_fetching_helpers/stat_statements_wrapper.sql
@@ -23,7 +23,10 @@ $$ LANGUAGE sql VOLATILE SECURITY DEFINER;
 $SQL$;
 BEGIN
   PERFORM 1 from pg_views where viewname = 'pg_stat_statements';
-  IF FOUND AND string_to_array( split_part(version(), ' ', 2), '.' )::int[] > ARRAY[9,1] THEN   --parameters normalized only from 9.2
+  IF (regexp_matches(
+      regexp_replace(current_setting('server_version'), '(beta|devel).*', '', 'g'),
+        E'\\d+\\.?\\d+?')
+      )[1]::double precision > 9.1 THEN   --parameters normalized only from 9.2
     EXECUTE format(l_sproc_text);
     EXECUTE 'REVOKE EXECUTE ON FUNCTION public.get_stat_statements() FROM PUBLIC;';
     EXECUTE 'GRANT EXECUTE ON FUNCTION public.get_stat_statements() TO pgwatch2';


### PR DESCRIPTION
Found an issue monitoring session information with the non-superuser role `pgwatch2`.

This PR adds a wrapper function to the database with privilege to execute only extended to `pgwatch2`, unless it is created by a superuser monitor login.

All existing metric queries have been updated to utilise the wrapper.