### PR TITLE
Added note for go requirements due to math.round() to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,9 +427,9 @@ All examples assuming Ubuntu.
     Check for the latest Go version from https://golang.org/dl/
     
     ```
-    # install Go (latest version preferably)
-    wget https://storage.googleapis.com/golang/go1.9.2.linux-amd64.tar.gz
-    tar -C /usr/local -xzf go1.9.2.linux-amd64.tar.gz
+    # install Go (latest version preferably, but at least 1.10)
+    wget https://dl.google.com/go/go1.11.linux-amd64.tar.gz
+    tar -C /usr/local -xzf go1.11.linux-amd64.tar.gz
     export PATH=$PATH:/usr/local/go/bin
     
     # compile the gatherer daemon


### PR DESCRIPTION
Hi there

I noted that commit 6db12e1755c843297f6aa982ce9dd2dcd96f7621 introduced new code which relies on Go's `math.round()`. This has only been added in Go 1.10, though the README.md for standalone installation still has 1.9.2 listed.

Even though it says "Install Go (latest version preferably)", I added the explicit remark that you absolutely need to have at least version 1.10 installed.

Just something minor, but nonetheless :)

Best regards

Lukas