### PR TITLE
Improve security of helper functions

### DIFF
--- a/pgwatch2/metrics/00_helpers/get_load_average/9.0/metric.sql
+++ b/pgwatch2/metrics/00_helpers/get_load_average/9.0/metric.sql
@@ -2,15 +2,16 @@ BEGIN;
 
 CREATE EXTENSION IF NOT EXISTS plpythonu;
 
-CREATE OR REPLACE FUNCTION get_load_average(OUT load_1min float, OUT load_5min float, OUT load_15min float) AS
+CREATE OR REPLACE FUNCTION public.get_load_average(OUT load_1min float, OUT load_5min float, OUT load_15min float) AS
 $$
 from os import getloadavg
 la = getloadavg()
 return [la[0], la[1], la[2]]
-$$ LANGUAGE plpythonu VOLATILE SECURITY DEFINER;
+$$ LANGUAGE plpythonu VOLATILE SECURITY DEFINER SET search_path = pg_catalog,pg_temp;
 
-GRANT EXECUTE ON FUNCTION get_load_average() TO pgwatch2;
+REVOKE EXECUTE ON FUNCTION public.get_load_average() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_load_average() TO pgwatch2;
 
-COMMENT ON FUNCTION get_load_average() is 'created for pgwatch2';
+COMMENT ON FUNCTION public.get_load_average() is 'created for pgwatch2';
 
 COMMIT;

--- a/pgwatch2/metrics/00_helpers/get_load_average_copy/9.1/metric.sql
+++ b/pgwatch2/metrics/00_helpers/get_load_average_copy/9.1/metric.sql
@@ -1,7 +1,7 @@
 /* for cases where PL/Python is not an option. not included in preset configs */
 BEGIN;
 
-CREATE UNLOGGED TABLE IF NOT EXISTS get_load_average_copy /* remove the UNLOGGED and IF NOT EXISTS part for < v9.1 */
+CREATE UNLOGGED TABLE IF NOT EXISTS public.get_load_average_copy /* remove the UNLOGGED and IF NOT EXISTS part for < v9.1 */
 (
     load_1min  float,
     load_5min  float,
@@ -11,20 +11,21 @@ CREATE UNLOGGED TABLE IF NOT EXISTS get_load_average_copy /* remove the UNLOGGED
     created_on timestamptz not null default now()
 );
 
-CREATE OR REPLACE FUNCTION get_load_average_copy(OUT load_1min float, OUT load_5min float, OUT load_15min float) AS
+CREATE OR REPLACE FUNCTION public.get_load_average_copy(OUT load_1min float, OUT load_5min float, OUT load_15min float) AS
 $$
 begin
     if random() < 0.02 then    /* clear the table on ca every 50th call not to be bigger than a couple of pages */
-        truncate get_load_average_copy;
+        truncate public.get_load_average_copy;
     end if;
-    copy get_load_average_copy (load_1min, load_5min, load_15min, proc_count, last_procid) from '/proc/loadavg' with (format csv, delimiter ' ');
-    select t.load_1min, t.load_5min, t.load_15min into load_1min, load_5min, load_15min from get_load_average_copy t order by created_on desc nulls last limit 1;
+    copy public.get_load_average_copy (load_1min, load_5min, load_15min, proc_count, last_procid) from '/proc/loadavg' with (format csv, delimiter ' ');
+    select t.load_1min, t.load_5min, t.load_15min into load_1min, load_5min, load_15min from public.get_load_average_copy t order by created_on desc nulls last limit 1;
     return;
 end;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog,pg_temp;
 
-GRANT EXECUTE ON FUNCTION get_load_average_copy() TO pgwatch2;
+REVOKE EXECUTE ON FUNCTION public.get_load_average_copy() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_load_average_copy() TO pgwatch2;
 
-COMMENT ON FUNCTION get_load_average_copy() is 'created for pgwatch2';
+COMMENT ON FUNCTION public.get_load_average_copy() is 'created for pgwatch2';
 
 COMMIT;

--- a/pgwatch2/metrics/00_helpers/get_psutil_cpu/9.1/metric.sql
+++ b/pgwatch2/metrics/00_helpers/get_psutil_cpu/9.1/metric.sql
@@ -4,12 +4,13 @@
 */
 CREATE EXTENSION IF NOT EXISTS plpythonu; /* NB! "plpythonu" might need changing to "plpython3u" everywhere for new OS-es */
 
-CREATE OR REPLACE FUNCTION get_psutil_cpu(
+CREATE OR REPLACE FUNCTION public.get_psutil_cpu(
 	OUT cpu_utilization float8, OUT load_1m_norm float8, OUT load_1m float8, OUT load_5m_norm float8, OUT load_5m float8,
     OUT "user" float8, OUT system float8, OUT idle float8, OUT iowait float8, OUT irqs float8, OUT other float8
 )
  LANGUAGE plpythonu
  SECURITY DEFINER
+ SET search_path = pg_catalog,pg_temp
 AS $FUNCTION$
 
 from os import getloadavg
@@ -37,5 +38,7 @@ return t.cpu_utilization_info, la[0] / cpu_count(), la[0], la[1] / cpu_count(), 
 
 $FUNCTION$;
 
-GRANT EXECUTE ON FUNCTION get_psutil_cpu() TO pgwatch2;
-COMMENT ON FUNCTION get_psutil_cpu() IS 'created for pgwatch2';
+REVOKE EXECUTE ON FUNCTION public.get_psutil_cpu() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_psutil_cpu() TO pgwatch2;
+
+COMMENT ON FUNCTION public.get_psutil_cpu() IS 'created for pgwatch2';

--- a/pgwatch2/metrics/00_helpers/get_psutil_disk/9.1/metric.sql
+++ b/pgwatch2/metrics/00_helpers/get_psutil_disk/9.1/metric.sql
@@ -1,7 +1,7 @@
 /* Pre-requisites: PL/Pythonu and "psutil" Python package (e.g. pip install psutil) */
 CREATE EXTENSION IF NOT EXISTS plpythonu; /* NB! "plpythonu" might need changing to "plpython3u" everywhere for new OS-es */
 
-CREATE OR REPLACE FUNCTION get_psutil_disk(
+CREATE OR REPLACE FUNCTION public.get_psutil_disk(
 	OUT dir_or_tablespace text, OUT path text, OUT total float8, OUT used float8, OUT free float8, OUT percent float8
 )
  RETURNS SETOF record
@@ -57,5 +57,7 @@ return ret_list
 
 $FUNCTION$;
 
-GRANT EXECUTE ON FUNCTION get_psutil_disk() TO pgwatch2;
-COMMENT ON FUNCTION get_psutil_disk() IS 'created for pgwatch2';
+REVOKE EXECUTE ON FUNCTION public.get_psutil_disk() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_psutil_disk() TO pgwatch2;
+
+COMMENT ON FUNCTION public.get_psutil_disk() IS 'created for pgwatch2';

--- a/pgwatch2/metrics/00_helpers/get_psutil_disk_io_total/9.1/metric.sql
+++ b/pgwatch2/metrics/00_helpers/get_psutil_disk_io_total/9.1/metric.sql
@@ -1,16 +1,19 @@
 /* Pre-requisites: PL/Pythonu and "psutil" Python package (e.g. pip install psutil) */
 CREATE EXTENSION IF NOT EXISTS plpythonu; /* NB! "plpythonu" might need changing to "plpython3u" everywhere for new OS-es */
 
-CREATE OR REPLACE FUNCTION get_psutil_disk_io_total(
+CREATE OR REPLACE FUNCTION public.get_psutil_disk_io_total(
 	OUT read_count float8, OUT write_count float8, OUT read_bytes float8, OUT write_bytes float8
 )
  LANGUAGE plpythonu
  SECURITY DEFINER
+ SET search_path = pg_catalog,pg_temp
 AS $FUNCTION$
 from psutil import disk_io_counters
 dc = disk_io_counters(perdisk=False)
 return dc.read_count, dc.write_count, dc.read_bytes, dc.write_bytes
 $FUNCTION$;
 
-GRANT EXECUTE ON FUNCTION get_psutil_disk_io_total() TO pgwatch2;
-COMMENT ON FUNCTION get_psutil_disk_io_total() IS 'created for pgwatch2';
+REVOKE EXECUTE ON FUNCTION public.get_psutil_disk_io_total() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_psutil_disk_io_total() TO pgwatch2;
+
+COMMENT ON FUNCTION public.get_psutil_disk_io_total() IS 'created for pgwatch2';

--- a/pgwatch2/metrics/00_helpers/get_psutil_mem/9.1/metric.sql
+++ b/pgwatch2/metrics/00_helpers/get_psutil_mem/9.1/metric.sql
@@ -1,7 +1,7 @@
 /* Pre-requisites: PL/Pythonu and "psutil" Python package (e.g. pip install psutil) */
 CREATE EXTENSION IF NOT EXISTS plpythonu; /* NB! "plpythonu" might need changing to "plpython3u" everywhere for new OS-es */
 
-CREATE OR REPLACE FUNCTION get_psutil_mem(
+CREATE OR REPLACE FUNCTION public.get_psutil_mem(
 	OUT total float8, OUT used float8, OUT free float8, OUT buff_cache float8, OUT available float8, OUT percent float8,
 	OUT swap_total float8, OUT swap_used float8, OUT swap_free float8, OUT swap_percent float8
 )
@@ -14,5 +14,7 @@ sw = swap_memory()
 return vm.total, vm.used, vm.free, vm.buffers + vm.cached, vm.available, vm.percent, sw.total, sw.used, sw.free, sw.percent
 $FUNCTION$;
 
-GRANT EXECUTE ON FUNCTION get_psutil_mem() TO pgwatch2;
-COMMENT ON FUNCTION get_psutil_mem() IS 'created for pgwatch2';
+REVOKE EXECUTE ON FUNCTION public.get_psutil_mem() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_psutil_mem() TO pgwatch2;
+
+COMMENT ON FUNCTION public.get_psutil_mem() IS 'created for pgwatch2';

--- a/pgwatch2/metrics/00_helpers/get_stat_activity/9.0/metric.sql
+++ b/pgwatch2/metrics/00_helpers/get_stat_activity/9.0/metric.sql
@@ -1,7 +1,9 @@
-CREATE OR REPLACE FUNCTION get_stat_activity() RETURNS SETOF pg_stat_activity AS
+CREATE OR REPLACE FUNCTION public.get_stat_activity() RETURNS SETOF pg_stat_activity AS
 $$
   select * from pg_stat_activity where datname = current_database() and procpid != pg_backend_pid()
 $$ LANGUAGE sql VOLATILE SECURITY DEFINER;
 
-GRANT EXECUTE ON FUNCTION get_stat_activity() TO pgwatch2;
-COMMENT ON FUNCTION get_stat_activity() IS 'created for pgwatch2';
+REVOKE EXECUTE ON FUNCTION public.get_stat_activity() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_stat_activity() TO pgwatch2;
+
+COMMENT ON FUNCTION public.get_stat_activity() IS 'created for pgwatch2';

--- a/pgwatch2/metrics/00_helpers/get_stat_activity/9.2/metric.sql
+++ b/pgwatch2/metrics/00_helpers/get_stat_activity/9.2/metric.sql
@@ -1,7 +1,9 @@
-CREATE OR REPLACE FUNCTION get_stat_activity() RETURNS SETOF pg_stat_activity AS
+CREATE OR REPLACE FUNCTION public.get_stat_activity() RETURNS SETOF pg_stat_activity AS
 $$
   select * from pg_stat_activity where datname = current_database() and pid != pg_backend_pid()
-$$ LANGUAGE sql VOLATILE SECURITY DEFINER;
+$$ LANGUAGE sql VOLATILE SECURITY DEFINER SET search_path = pg_catalog,pg_temp;
 
-GRANT EXECUTE ON FUNCTION get_stat_activity() TO pgwatch2;
-COMMENT ON FUNCTION get_stat_activity() IS 'created for pgwatch2';
+REVOKE EXECUTE ON FUNCTION public.get_stat_activity() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_stat_activity() TO pgwatch2;
+
+COMMENT ON FUNCTION public.get_stat_activity() IS 'created for pgwatch2';

--- a/pgwatch2/metrics/00_helpers/get_stat_replication/9.0/metric.sql
+++ b/pgwatch2/metrics/00_helpers/get_stat_replication/9.0/metric.sql
@@ -1,7 +1,9 @@
-CREATE OR REPLACE FUNCTION get_stat_replication() RETURNS SETOF pg_stat_replication AS
+CREATE OR REPLACE FUNCTION public.get_stat_replication() RETURNS SETOF pg_stat_replication AS
 $$
   select * from pg_stat_replication
-$$ LANGUAGE sql VOLATILE SECURITY DEFINER;
+$$ LANGUAGE sql VOLATILE SECURITY DEFINER SET search_path = pg_catalog,pg_temp;
 
-GRANT EXECUTE ON FUNCTION get_stat_replication() TO pgwatch2;
-COMMENT ON FUNCTION get_stat_replication() IS 'created for pgwatch2';
+REVOKE EXECUTE ON FUNCTION public.get_stat_replication() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_stat_replication() TO pgwatch2;
+
+COMMENT ON FUNCTION public.get_stat_replication() IS 'created for pgwatch2';

--- a/pgwatch2/metrics/00_helpers/get_stat_statements/9.2/metric.sql
+++ b/pgwatch2/metrics/00_helpers/get_stat_statements/9.2/metric.sql
@@ -1,12 +1,12 @@
-CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements SCHEMA public;
 
 DO $OUTER$
 DECLARE
   l_sproc_text text := $_SQL_$
-CREATE OR REPLACE FUNCTION get_stat_statements() RETURNS SETOF pg_stat_statements AS
+CREATE OR REPLACE FUNCTION public.get_stat_statements() RETURNS SETOF pg_stat_statements AS
 $$
-  select s.* from pg_stat_statements s join pg_database d on d.oid = s.dbid and d.datname = current_database()
-$$ LANGUAGE sql VOLATILE SECURITY DEFINER;
+  select s.* from public.pg_stat_statements s join pg_database d on d.oid = s.dbid and d.datname = current_database()
+$$ LANGUAGE sql VOLATILE SECURITY DEFINER SET search_path = pg_catalog,pg_temp;
 $_SQL_$;
 BEGIN
   IF (regexp_matches(
@@ -14,8 +14,9 @@ BEGIN
         E'\\d+\\.?\\d+?')
       )[1]::double precision > 9.1 THEN   --parameters normalized only from 9.2
     EXECUTE format(l_sproc_text);
-    EXECUTE 'GRANT EXECUTE ON FUNCTION get_stat_statements() TO pgwatch2';
-    EXECUTE 'COMMENT ON FUNCTION get_stat_statements() IS ''created for pgwatch2''';
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION public.get_stat_statements() FROM PUBLIC';
+    EXECUTE 'GRANT EXECUTE ON FUNCTION public.get_stat_statements() TO pgwatch2';
+    EXECUTE 'COMMENT ON FUNCTION public.get_stat_statements() IS ''created for pgwatch2''';
   END IF;
 END;
 $OUTER$;

--- a/pgwatch2/metrics/00_helpers/get_table_bloat_approx/9.5/metric.sql
+++ b/pgwatch2/metrics/00_helpers/get_table_bloat_approx/9.5/metric.sql
@@ -1,12 +1,12 @@
 BEGIN;
 
-CREATE EXTENSION IF NOT EXISTS pgstattuple;
+CREATE EXTENSION IF NOT EXISTS pgstattuple SCHEMA public;
 
 DO $OUTER$
 
 DECLARE
   l_sproc_text text := $_SQL_$
-CREATE OR REPLACE FUNCTION get_table_bloat_approx(
+CREATE OR REPLACE FUNCTION public.get_table_bloat_approx(
   OUT approx_free_percent double precision, OUT approx_free_space double precision,
   OUT dead_tuple_percent double precision, OUT dead_tuple_len double precision) AS
 $$
@@ -19,12 +19,12 @@ $$
       pg_class c
       join
       pg_namespace n on n.oid = c.relnamespace
-      join lateral pgstattuple_approx(c.oid) on (c.oid not in (select relation from pg_locks where mode = 'AccessExclusiveLock'))  -- skip locked tables
+      join lateral public.pgstattuple_approx(c.oid) on (c.oid not in (select relation from pg_locks where mode = 'AccessExclusiveLock'))  -- skip locked tables
     where
       relkind in ('r', 'm')
       and c.relpages >= 128 -- tables >1mb
       and not n.nspname like any (array[E'pg\\_%', 'information_schema'])
-$$ LANGUAGE sql SECURITY DEFINER;
+$$ LANGUAGE sql SECURITY DEFINER SET search_path = pg_catalog,pg_temp;
 $_SQL_$;
 
 BEGIN
@@ -34,8 +34,9 @@ BEGIN
       )[1]::double precision > 9.4 THEN
     EXECUTE l_sproc_text;
 
-    EXECUTE 'GRANT EXECUTE ON FUNCTION get_table_bloat_approx() TO pgwatch2;';
-    EXECUTE 'COMMENT ON FUNCTION get_table_bloat_approx() is ''created for pgwatch2''';
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION public.get_table_bloat_approx() FROM PUBLIC;';
+    EXECUTE 'GRANT EXECUTE ON FUNCTION public.get_table_bloat_approx() TO pgwatch2;';
+    EXECUTE 'COMMENT ON FUNCTION public.get_table_bloat_approx() is ''created for pgwatch2''';
   END IF;
 END;
 $OUTER$;

--- a/pgwatch2/metrics/00_helpers/get_table_bloat_approx_sql/12/metric.sql
+++ b/pgwatch2/metrics/00_helpers/get_table_bloat_approx_sql/12/metric.sql
@@ -1,7 +1,7 @@
 -- small modifications to SQL from https://github.com/ioguix/pgsql-bloat-estimation
 -- NB! monitoring user needs SELECT grant on all tables or a SECURITY DEFINER wrapper around that SQL
 
-CREATE OR REPLACE FUNCTION get_table_bloat_approx_sql(
+CREATE OR REPLACE FUNCTION public.get_table_bloat_approx_sql(
       OUT full_table_name text,
       OUT approx_bloat_percent double precision,
       OUT approx_bloat_bytes double precision,
@@ -9,6 +9,7 @@ CREATE OR REPLACE FUNCTION get_table_bloat_approx_sql(
     ) RETURNS SETOF RECORD
 LANGUAGE sql
 SECURITY DEFINER
+SET search_path = pg_catalog,pg_temp
 AS $$
 
 SELECT
@@ -124,5 +125,7 @@ FROM (
  ) s4
 $$;
 
-GRANT EXECUTE ON FUNCTION get_table_bloat_approx_sql() TO pgwatch2;
-COMMENT ON FUNCTION get_table_bloat_approx_sql() is 'created for pgwatch2';
+REVOKE EXECUTE ON FUNCTION public.get_table_bloat_approx_sql() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_table_bloat_approx_sql() TO pgwatch2;
+
+COMMENT ON FUNCTION public.get_table_bloat_approx_sql() is 'created for pgwatch2';

--- a/pgwatch2/metrics/00_helpers/get_table_bloat_approx_sql/9.0/metric.sql
+++ b/pgwatch2/metrics/00_helpers/get_table_bloat_approx_sql/9.0/metric.sql
@@ -1,7 +1,7 @@
 -- small modifications to SQL from https://github.com/ioguix/pgsql-bloat-estimation
 -- NB! monitoring user needs SELECT grant on all tables or a SECURITY DEFINER wrapper around that SQL
 
-CREATE OR REPLACE FUNCTION get_table_bloat_approx_sql(
+CREATE OR REPLACE FUNCTION public.get_table_bloat_approx_sql(
       OUT full_table_name text,
       OUT approx_bloat_percent double precision,
       OUT approx_bloat_bytes double precision,
@@ -9,6 +9,7 @@ CREATE OR REPLACE FUNCTION get_table_bloat_approx_sql(
     ) RETURNS SETOF RECORD
 LANGUAGE sql
 SECURITY DEFINER
+SET search_path = pg_catalog,pg_temp
 AS $$
 
 SELECT
@@ -124,5 +125,7 @@ FROM (
  ) s4
 $$;
 
-GRANT EXECUTE ON FUNCTION get_table_bloat_approx_sql() TO pgwatch2;
-COMMENT ON FUNCTION get_table_bloat_approx_sql() is 'created for pgwatch2';
+REVOKE EXECUTE ON FUNCTION public.get_table_bloat_approx_sql() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_table_bloat_approx_sql() TO pgwatch2;
+
+COMMENT ON FUNCTION public.get_table_bloat_approx_sql() is 'created for pgwatch2';

--- a/pgwatch2/metrics/00_helpers/get_wal_size/10/metric.sql
+++ b/pgwatch2/metrics/00_helpers/get_wal_size/10/metric.sql
@@ -1,7 +1,9 @@
-CREATE OR REPLACE FUNCTION get_wal_size() RETURNS int8 AS
+CREATE OR REPLACE FUNCTION public.get_wal_size() RETURNS int8 AS
 $$
 select (sum((pg_stat_file('pg_wal/' || name)).size))::int8 from pg_ls_waldir()
 $$ LANGUAGE sql VOLATILE SECURITY DEFINER;
 
-GRANT EXECUTE ON FUNCTION get_wal_size() TO pgwatch2;
-COMMENT ON FUNCTION get_wal_size() IS 'created for pgwatch2';
+REVOKE EXECUTE ON FUNCTION public.get_wal_size() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_wal_size() TO pgwatch2;
+
+COMMENT ON FUNCTION public.get_wal_size() IS 'created for pgwatch2';

--- a/pgwatch2/sql/metric_fetching_helpers/cpu_load_plpythonu.sql
+++ b/pgwatch2/sql/metric_fetching_helpers/cpu_load_plpythonu.sql
@@ -9,15 +9,16 @@ BEGIN;
 
 CREATE EXTENSION IF NOT EXISTS plpythonu; /* NB! "plpythonu" might need changing to "plpython3u" everywhere for new OS-es */
 
-CREATE OR REPLACE FUNCTION get_load_average(OUT load_1min float, OUT load_5min float, OUT load_15min float) AS
+CREATE OR REPLACE FUNCTION public.get_load_average(OUT load_1min float, OUT load_5min float, OUT load_15min float) AS
 $$
 from os import getloadavg
 la = getloadavg()
 return [la[0], la[1], la[2]]
 $$ LANGUAGE plpythonu VOLATILE SECURITY DEFINER;
 
-GRANT EXECUTE ON FUNCTION get_load_average() TO pgwatch2;
+REVOKE EXECUTE ON FUNCTION public.get_load_average() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_load_average() TO pgwatch2;
 
-COMMENT ON FUNCTION get_load_average() is 'created for pgwatch2';
+COMMENT ON FUNCTION public.get_load_average() is 'created for pgwatch2';
 
 COMMIT;

--- a/pgwatch2/sql/metric_fetching_helpers/cpu_load_without_plpython.sql
+++ b/pgwatch2/sql/metric_fetching_helpers/cpu_load_without_plpython.sql
@@ -1,7 +1,7 @@
 /* for cases where PL/Python is not an option. not included in preset configs */
 BEGIN;
 
-CREATE UNLOGGED TABLE IF NOT EXISTS get_load_average_copy /* remove the UNLOGGED and IF NOT EXISTS part for < v9.1 */
+CREATE UNLOGGED TABLE IF NOT EXISTS public.get_load_average_copy /* remove the UNLOGGED and IF NOT EXISTS part for < v9.1 */
 (
     load_1min  float,
     load_5min  float,
@@ -11,20 +11,21 @@ CREATE UNLOGGED TABLE IF NOT EXISTS get_load_average_copy /* remove the UNLOGGED
     created_on timestamptz not null default now()
 );
 
-CREATE OR REPLACE FUNCTION get_load_average_copy(OUT load_1min float, OUT load_5min float, OUT load_15min float) AS
+CREATE OR REPLACE FUNCTION public.get_load_average_copy(OUT load_1min float, OUT load_5min float, OUT load_15min float) AS
 $$
 begin
     if random() < 0.02 then    /* clear the table on ca every 50th call not to be bigger than a couple of pages */
-        truncate get_load_average_copy;
+        truncate public.get_load_average_copy;
     end if;
-    copy get_load_average_copy (load_1min, load_5min, load_15min, proc_count, last_procid) from '/proc/loadavg' with (format csv, delimiter ' ');
-    select t.load_1min, t.load_5min, t.load_15min into load_1min, load_5min, load_15min from get_load_average_copy t order by created_on desc nulls last limit 1;
+    copy public.get_load_average_copy (load_1min, load_5min, load_15min, proc_count, last_procid) from '/proc/loadavg' with (format csv, delimiter ' ');
+    select t.load_1min, t.load_5min, t.load_15min into load_1min, load_5min, load_15min from public.get_load_average_copy t order by created_on desc nulls last limit 1;
     return;
 end;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog,pg_temp;
 
-GRANT EXECUTE ON FUNCTION get_load_average_copy() TO pgwatch2;
+REVOKE EXECUTE ON FUNCTION public.get_load_average_copy() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_load_average_copy() TO pgwatch2;
 
-COMMENT ON FUNCTION get_load_average_copy() is 'created for pgwatch2';
+COMMENT ON FUNCTION public.get_load_average_copy() is 'created for pgwatch2';
 
 COMMIT;

--- a/pgwatch2/sql/metric_fetching_helpers/psutil_cpu.sql
+++ b/pgwatch2/sql/metric_fetching_helpers/psutil_cpu.sql
@@ -4,12 +4,13 @@
 */
 CREATE EXTENSION IF NOT EXISTS plpythonu; /* NB! "plpythonu" might need changing to "plpython3u" everywhere for new OS-es */
 
-CREATE OR REPLACE FUNCTION get_psutil_cpu(
+CREATE OR REPLACE FUNCTION public.get_psutil_cpu(
 	OUT cpu_utilization float8, OUT load_1m_norm float8, OUT load_1m float8, OUT load_5m_norm float8, OUT load_5m float8,
     OUT "user" float8, OUT system float8, OUT idle float8, OUT iowait float8, OUT irqs float8, OUT other float8
 )
  LANGUAGE plpythonu
  SECURITY DEFINER
+ SET search_path = pg_catalog,pg_temp
 AS $FUNCTION$
 
 from os import getloadavg
@@ -37,5 +38,7 @@ return t.cpu_utilization_info, la[0] / cpu_count(), la[0], la[1] / cpu_count(), 
 
 $FUNCTION$;
 
-GRANT EXECUTE ON FUNCTION get_psutil_cpu() TO pgwatch2;
-COMMENT ON FUNCTION get_psutil_cpu() IS 'created for pgwatch2';
+REVOKE EXECUTE ON FUNCTION public.get_psutil_cpu() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_psutil_cpu() TO pgwatch2;
+
+COMMENT ON FUNCTION public.get_psutil_cpu() IS 'created for pgwatch2';

--- a/pgwatch2/sql/metric_fetching_helpers/psutil_disk.sql
+++ b/pgwatch2/sql/metric_fetching_helpers/psutil_disk.sql
@@ -1,12 +1,13 @@
 /* Pre-requisites: PL/Pythonu and "psutil" Python package (e.g. pip install psutil) */
 CREATE EXTENSION IF NOT EXISTS plpythonu; /* NB! "plpythonu" might need changing to "plpython3u" everywhere for new OS-es */
 
-CREATE OR REPLACE FUNCTION get_psutil_disk(
+CREATE OR REPLACE FUNCTION public.get_psutil_disk(
 	OUT dir_or_tablespace text, OUT path text, OUT total float8, OUT used float8, OUT free float8, OUT percent float8
 )
  RETURNS SETOF record
  LANGUAGE plpythonu
  SECURITY DEFINER
+ SET search_path = pg_catalog,pg_temp
 AS $FUNCTION$
 
 from os import stat
@@ -57,5 +58,7 @@ return ret_list
 
 $FUNCTION$;
 
-GRANT EXECUTE ON FUNCTION get_psutil_disk() TO pgwatch2;
-COMMENT ON FUNCTION get_psutil_disk() IS 'created for pgwatch2';
+REVOKE EXECUTE ON FUNCTION public.get_psutil_disk() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_psutil_disk() TO pgwatch2;
+
+COMMENT ON FUNCTION public.get_psutil_disk() IS 'created for pgwatch2';

--- a/pgwatch2/sql/metric_fetching_helpers/psutil_disk_io_total.sql
+++ b/pgwatch2/sql/metric_fetching_helpers/psutil_disk_io_total.sql
@@ -1,16 +1,19 @@
 /* Pre-requisites: PL/Pythonu and "psutil" Python package (e.g. pip install psutil) */
 CREATE EXTENSION IF NOT EXISTS plpythonu; /* NB! "plpythonu" might need changing to "plpython3u" everywhere for new OS-es */
 
-CREATE OR REPLACE FUNCTION get_psutil_disk_io_total(
+CREATE OR REPLACE FUNCTION public.get_psutil_disk_io_total(
 	OUT read_count float8, OUT write_count float8, OUT read_bytes float8, OUT write_bytes float8
 )
  LANGUAGE plpythonu
  SECURITY DEFINER
+ SET search_path = pg_catalog,pg_temp
 AS $FUNCTION$
 from psutil import disk_io_counters
 dc = disk_io_counters(perdisk=False)
 return dc.read_count, dc.write_count, dc.read_bytes, dc.write_bytes
 $FUNCTION$;
 
-GRANT EXECUTE ON FUNCTION get_psutil_disk_io_total() TO pgwatch2;
-COMMENT ON FUNCTION get_psutil_disk_io_total() IS 'created for pgwatch2';
+REVOKE EXECUTE ON FUNCTION public.get_psutil_disk_io_total() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_psutil_disk_io_total() TO pgwatch2;
+
+COMMENT ON FUNCTION public.get_psutil_disk_io_total() IS 'created for pgwatch2';

--- a/pgwatch2/sql/metric_fetching_helpers/psutil_mem.sql
+++ b/pgwatch2/sql/metric_fetching_helpers/psutil_mem.sql
@@ -1,12 +1,13 @@
 /* Pre-requisites: PL/Pythonu and "psutil" Python package (e.g. pip install psutil) */
 CREATE EXTENSION IF NOT EXISTS plpythonu; /* NB! "plpythonu" might need changing to "plpython3u" everywhere for new OS-es */
 
-CREATE OR REPLACE FUNCTION get_psutil_mem(
+CREATE OR REPLACE FUNCTION public.get_psutil_mem(
 	OUT total float8, OUT used float8, OUT free float8, OUT buff_cache float8, OUT available float8, OUT percent float8,
 	OUT swap_total float8, OUT swap_used float8, OUT swap_free float8, OUT swap_percent float8
 )
  LANGUAGE plpythonu
  SECURITY DEFINER
+ SET search_path = pg_catalog,pg_temp
 AS $FUNCTION$
 from psutil import virtual_memory, swap_memory
 vm = virtual_memory()
@@ -14,5 +15,7 @@ sw = swap_memory()
 return vm.total, vm.used, vm.free, vm.buffers + vm.cached, vm.available, vm.percent, sw.total, sw.used, sw.free, sw.percent
 $FUNCTION$;
 
-GRANT EXECUTE ON FUNCTION get_psutil_mem() TO pgwatch2;
-COMMENT ON FUNCTION get_psutil_mem() IS 'created for pgwatch2';
+REVOKE EXECUTE ON FUNCTION public.get_psutil_mem() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_psutil_mem() TO pgwatch2;
+
+COMMENT ON FUNCTION public.get_psutil_mem() IS 'created for pgwatch2';

--- a/pgwatch2/sql/metric_fetching_helpers/stat_activity_wrapper.sql
+++ b/pgwatch2/sql/metric_fetching_helpers/stat_activity_wrapper.sql
@@ -8,16 +8,16 @@ DO $OUTER$
 DECLARE
   l_pgver double precision;
   l_sproc_text_pre92 text := $SQL$
-CREATE OR REPLACE FUNCTION get_stat_activity() RETURNS SETOF pg_stat_activity AS
+CREATE OR REPLACE FUNCTION public.get_stat_activity() RETURNS SETOF pg_stat_activity AS
 $$
   select * from pg_stat_activity where datname = current_database() and procpid != pg_backend_pid()
-$$ LANGUAGE sql VOLATILE SECURITY DEFINER;
+$$ LANGUAGE sql VOLATILE SECURITY DEFINER SET search_path = pg_catalog,pg_temp;
 $SQL$;
   l_sproc_text_92_plus text := $SQL$
-CREATE OR REPLACE FUNCTION get_stat_activity() RETURNS SETOF pg_stat_activity AS
+CREATE OR REPLACE FUNCTION public.get_stat_activity() RETURNS SETOF pg_stat_activity AS
 $$
   select * from pg_stat_activity where datname = current_database() and pid != pg_backend_pid()
-$$ LANGUAGE sql VOLATILE SECURITY DEFINER;
+$$ LANGUAGE sql VOLATILE SECURITY DEFINER SET search_path = pg_catalog,pg_temp;
 $SQL$;
 BEGIN
   SELECT ((regexp_matches(
@@ -27,5 +27,7 @@ BEGIN
 END;
 $OUTER$;
 
-GRANT EXECUTE ON FUNCTION get_stat_activity() TO pgwatch2;
-COMMENT ON FUNCTION get_stat_activity() IS 'created for pgwatch2';
+REVOKE EXECUTE ON FUNCTION public.get_stat_activity() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_stat_activity() TO pgwatch2;
+
+COMMENT ON FUNCTION public.get_stat_activity() IS 'created for pgwatch2';

--- a/pgwatch2/sql/metric_fetching_helpers/stat_replication.sql
+++ b/pgwatch2/sql/metric_fetching_helpers/stat_replication.sql
@@ -1,7 +1,9 @@
-CREATE OR REPLACE FUNCTION get_stat_replication() RETURNS SETOF pg_stat_replication AS
+CREATE OR REPLACE FUNCTION public.get_stat_replication() RETURNS SETOF pg_stat_replication AS
 $$
   select * from pg_stat_replication
-$$ LANGUAGE sql VOLATILE SECURITY DEFINER;
+$$ LANGUAGE sql VOLATILE SECURITY DEFINER SET search_path = pg_catalog,pg_temp;
 
-GRANT EXECUTE ON FUNCTION get_stat_replication() TO pgwatch2;
-COMMENT ON FUNCTION get_stat_replication() IS 'created for pgwatch2';
+REVOKE EXECUTE ON FUNCTION public.get_stat_replication() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_stat_replication() TO pgwatch2;
+
+COMMENT ON FUNCTION public.get_stat_replication() IS 'created for pgwatch2';

--- a/pgwatch2/sql/metric_fetching_helpers/table_bloat_approx.sql
+++ b/pgwatch2/sql/metric_fetching_helpers/table_bloat_approx.sql
@@ -1,12 +1,12 @@
 BEGIN;
 
-CREATE EXTENSION IF NOT EXISTS pgstattuple;
+CREATE EXTENSION IF NOT EXISTS pgstattuple SCHEMA public;
 
 DO $OUTER$
 
 DECLARE
   l_sproc_text text := $_SQL_$
-CREATE OR REPLACE FUNCTION get_table_bloat_approx(
+CREATE OR REPLACE FUNCTION public.get_table_bloat_approx(
   OUT approx_free_percent double precision, OUT approx_free_space double precision,
   OUT dead_tuple_percent double precision, OUT dead_tuple_len double precision) AS
 $$
@@ -19,12 +19,12 @@ $$
       pg_class c
       join
       pg_namespace n on n.oid = c.relnamespace
-      join lateral pgstattuple_approx(c.oid) on (c.oid not in (select relation from pg_locks where mode = 'AccessExclusiveLock'))  -- skip locked tables
+      join lateral public.pgstattuple_approx(c.oid) on (c.oid not in (select relation from pg_locks where mode = 'AccessExclusiveLock'))  -- skip locked tables
     where
       relkind in ('r', 'm')
       and c.relpages >= 128 -- tables >1mb
       and not n.nspname like any (array[E'pg\\_%', 'information_schema'])
-$$ LANGUAGE sql SECURITY DEFINER;
+$$ LANGUAGE sql SECURITY DEFINER SET search_path = pg_catalog,pg_temp;
 $_SQL_$;
 
 BEGIN
@@ -34,8 +34,9 @@ BEGIN
       )[1]::double precision > 9.4 THEN
     EXECUTE l_sproc_text;
 
-    EXECUTE 'GRANT EXECUTE ON FUNCTION get_table_bloat_approx() TO pgwatch2;';
-    EXECUTE 'COMMENT ON FUNCTION get_table_bloat_approx() is ''created for pgwatch2''';
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION public.get_table_bloat_approx() FROM PUBLIC;';
+    EXECUTE 'GRANT EXECUTE ON FUNCTION public.get_table_bloat_approx() TO pgwatch2;';
+    EXECUTE 'COMMENT ON FUNCTION public.get_table_bloat_approx() is ''created for pgwatch2''';
   END IF;
 END;
 $OUTER$;

--- a/pgwatch2/sql/metric_fetching_helpers/table_bloat_approx_sql.sql
+++ b/pgwatch2/sql/metric_fetching_helpers/table_bloat_approx_sql.sql
@@ -1,7 +1,7 @@
 -- small modifications to SQL from https://github.com/ioguix/pgsql-bloat-estimation
 -- NB! monitoring user needs SELECT grant on all tables or a SECURITY DEFINER wrapper around that SQL
 
-CREATE OR REPLACE FUNCTION get_table_bloat_approx_sql(
+CREATE OR REPLACE FUNCTION public.get_table_bloat_approx_sql(
     OUT full_table_name text,
     OUT approx_bloat_percent double precision,
     OUT approx_bloat_bytes double precision,
@@ -9,6 +9,7 @@ CREATE OR REPLACE FUNCTION get_table_bloat_approx_sql(
 ) RETURNS SETOF RECORD
     LANGUAGE sql
     SECURITY DEFINER
+    SET search_path = pg_catalog,pg_temp
 AS $$
 
 SELECT
@@ -124,5 +125,7 @@ FROM (
      ) s4
 $$;
 
-GRANT EXECUTE ON FUNCTION get_table_bloat_approx_sql() TO pgwatch2;
-COMMENT ON FUNCTION get_table_bloat_approx_sql() is 'created for pgwatch2';
+REVOKE EXECUTE ON FUNCTION public.get_table_bloat_approx_sql() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_table_bloat_approx_sql() TO pgwatch2;
+
+COMMENT ON FUNCTION public.get_table_bloat_approx_sql() is 'created for pgwatch2';

--- a/pgwatch2/sql/metric_fetching_helpers/wal_size.sql
+++ b/pgwatch2/sql/metric_fetching_helpers/wal_size.sql
@@ -1,7 +1,9 @@
-CREATE OR REPLACE FUNCTION get_wal_size() RETURNS int8 AS
+CREATE OR REPLACE FUNCTION public.get_wal_size() RETURNS int8 AS
 $$
 select (sum((pg_stat_file('pg_wal/' || name)).size))::int8 from pg_ls_waldir()
-$$ LANGUAGE sql VOLATILE SECURITY DEFINER;
+$$ LANGUAGE sql VOLATILE SECURITY DEFINER SET search_path = pg_catalog,pg_temp;
 
-GRANT EXECUTE ON FUNCTION get_wal_size() TO pgwatch2;
-COMMENT ON FUNCTION get_wal_size() IS 'created for pgwatch2';
+REVOKE EXECUTE ON FUNCTION public.get_wal_size() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_wal_size() TO pgwatch2;
+
+COMMENT ON FUNCTION public.get_wal_size() IS 'created for pgwatch2';

--- a/pgwatch2/sql/metric_store/00_schema_base.sql
+++ b/pgwatch2/sql/metric_store/00_schema_base.sql
@@ -86,6 +86,7 @@ BEGIN
   RETURN false;
 END;
 $SQL$ LANGUAGE plpgsql;
+REVOKE EXECUTE ON FUNCTION admin.ensure_dummy_metrics_table(text) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION admin.ensure_dummy_metrics_table(text) TO pgwatch2;
 
 

--- a/pgwatch2/sql/metric_store/01_old_metrics_cleanup_procedure.sql
+++ b/pgwatch2/sql/metric_store/01_old_metrics_cleanup_procedure.sql
@@ -13,6 +13,7 @@ $SQL$
   and pg_catalog.obj_description(c.oid, 'pg_class') = 'pgwatch2-generated-metric-lvl'
   order by 1
 $SQL$ LANGUAGE sql;
+REVOKE EXECUTE ON FUNCTION admin.get_top_level_metric_tables() FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION admin.get_top_level_metric_tables() TO pgwatch2;
 
 
@@ -37,6 +38,7 @@ BEGIN
   RETURN i;
 END;
 $SQL$ LANGUAGE plpgsql;
+REVOKE EXECUTE ON FUNCTION admin.drop_all_metric_tables() FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION admin.drop_all_metric_tables() TO pgwatch2;
 
 
@@ -61,6 +63,7 @@ BEGIN
   RETURN i;
 END;
 $SQL$ LANGUAGE plpgsql;
+REVOKE EXECUTE ON FUNCTION admin.truncate_all_metric_tables() FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION admin.truncate_all_metric_tables() TO pgwatch2;
 
 
@@ -113,6 +116,7 @@ BEGIN
   RETURN i;
 END;
 $SQL$ LANGUAGE plpgsql;
+REVOKE EXECUTE ON FUNCTION admin.remove_single_dbname_data(text) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION admin.remove_single_dbname_data(text) TO pgwatch2;
 
 
@@ -172,4 +176,5 @@ BEGIN
   RETURN i;
 END;
 $SQL$ LANGUAGE plpgsql;
+REVOKE EXECUTE ON FUNCTION admin.drop_old_time_partitions(int,bool) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION admin.drop_old_time_partitions(int,bool) TO pgwatch2;

--- a/pgwatch2/sql/metric_store/metric-dbname-time/ensure_partition_metric_dbname_time.sql
+++ b/pgwatch2/sql/metric_store/metric-dbname-time/ensure_partition_metric_dbname_time.sql
@@ -134,4 +134,5 @@ BEGIN
 END;
 $SQL$ LANGUAGE plpgsql;
 
+REVOKE EXECUTE ON FUNCTION admin.ensure_partition_metric_dbname_time(text,text,timestamp with time zone,integer) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION admin.ensure_partition_metric_dbname_time(text,text,timestamp with time zone,integer) TO pgwatch2;

--- a/pgwatch2/sql/metric_store/metric-time/ensure_partition_metric_time.sql
+++ b/pgwatch2/sql/metric_store/metric-time/ensure_partition_metric_time.sql
@@ -96,4 +96,5 @@ BEGIN
 END;
 $SQL$ LANGUAGE plpgsql;
 
+REVOKE EXECUTE ON FUNCTION admin.ensure_partition_metric_time(text,timestamp with time zone,integer) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION admin.ensure_partition_metric_time(text,timestamp with time zone,integer) TO pgwatch2;

--- a/pgwatch2/sql/metric_store/metric/ensure_partition.sql
+++ b/pgwatch2/sql/metric_store/metric/ensure_partition.sql
@@ -32,4 +32,5 @@ BEGIN
 END;
 $SQL$ LANGUAGE plpgsql;
 
+REVOKE EXECUTE ON FUNCTION admin.ensure_partition_metric(text) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION admin.ensure_partition_metric(text) TO pgwatch2;


### PR DESCRIPTION
- all SECURITY DEFINER function must have "search_path" set to avoid privilege
  escalation attacks
- create all extensions in schema "public"
  (because their objects must be referenced with the schema in the functions)
- explicitly create all functions in schema "public" as well
  (since the previous point forces the existence of that schema anyway)
- revoke execute on all functions from PUBLIC

Installations that do not have this patch are vulnerable to privilege escalation
attacks by database users.