### PR TITLE
latest grafana w/ enterprise version

### DIFF
--- a/docker/Dockerfile-postgres
+++ b/docker/Dockerfile-postgres
@@ -16,7 +16,7 @@ RUN apt-get -q update && DEBIAN_FRONTEND=noninteractive apt-get install -qy curl
 # Influxdb [https://portal.influxdata.com/downloads]
 #   latest ver.: curl -so- https://api.github.com/repos/influxdata/influxdb/tags | grep -Eo '"v[0-9\.]+"' | grep -Eo '[0-9\.]+' | sort -nr | head -1
 
-RUN wget -q -O grafana.deb https://dl.grafana.com/oss/release/grafana_6.6.2_amd64.deb \
+RUN wget -q -O grafana.deb https://dl.grafana.com/enterprise/release/grafana-enterprise_6.7.1_amd64.deb \
     && dpkg -i grafana.deb && rm grafana.deb
 
 


### PR DESCRIPTION
update to latest grafana (6.7.1), and use enterprise edition instead.
same as open source version, but a license can be assigned for use of more features (eg. reporting).
it can still be used free of charge without license, and users will not notice anything different from the open-source version.