### PR TITLE
Add badge to display docker pulls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Docker Pulls](https://img.shields.io/docker/pulls/cybertec/pgwatch2)
+
 # pgwatch2
 
 Flexible self-contained PostgreSQL metrics monitoring/dashboarding solution. Supports monitoring PG versions 9.0 to 12 out of the box.


### PR DESCRIPTION
Add a badge to display the total amount of docker pulls to the README.

![Screen Shot 2020-06-30 at 10 14 09](https://user-images.githubusercontent.com/10603631/86101379-77835300-baba-11ea-8a4a-15e37a14cf5a.png)
