### PR TITLE
More secure SECURITY DEFINER helpers

### DIFF
--- a/pgwatch2/metrics/00_helpers/get_load_average_copy/9.1/metric.sql
+++ b/pgwatch2/metrics/00_helpers/get_load_average_copy/9.1/metric.sql
@@ -27,4 +27,21 @@ GRANT EXECUTE ON FUNCTION get_load_average_copy() TO pgwatch2;
 
 COMMENT ON FUNCTION get_load_average_copy() is 'created for pgwatch2';
 
+DO $SQL$
+    DECLARE
+        l_actual_schema text;
+    BEGIN
+        SELECT n.nspname INTO l_actual_schema FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE proname = 'get_load_average_copy';
+        IF FOUND THEN
+            IF has_schema_privilege('public', l_actual_schema, 'CREATE') THEN
+                RAISE EXCEPTION $$get_load_average_copy() helper should not be created in an unsecured schema where all users can create objects -
+                  'REVOKE CREATE ON SCHEMA % FROM public' to tighten security or comment out the DO block to disable the check$$, l_actual_schema;
+            END IF;
+
+            RAISE NOTICE '%', format($$ALTER FUNCTION get_load_average_copy() SET search_path TO %s$$, l_actual_schema);
+            EXECUTE format($$ALTER FUNCTION get_load_average_copy() SET search_path TO %s$$, l_actual_schema);
+        END IF;
+    END
+$SQL$;
+
 COMMIT;

--- a/pgwatch2/metrics/00_helpers/get_stat_statements/9.2/metric.sql
+++ b/pgwatch2/metrics/00_helpers/get_stat_statements/9.2/metric.sql
@@ -38,21 +38,28 @@ $$ LANGUAGE sql VOLATILE SECURITY DEFINER;
 GRANT EXECUTE ON FUNCTION get_stat_statements() TO pgwatch2;
 COMMENT ON FUNCTION get_stat_statements() IS 'created for pgwatch2';
 
+-- below routine fixes function search_path to only include "more secure" schemas with no "public" CREATE privileges
 DO $SQL$
     DECLARE
-        l_actual_schema text;
+        l_secure_schemas_from_search_path text;
     BEGIN
-        SELECT n.nspname INTO l_actual_schema FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE proname = 'get_stat_statements';
-        IF FOUND THEN
-            IF has_schema_privilege('public', l_actual_schema, 'CREATE') THEN
-                RAISE EXCEPTION $$get_stat_statements() helper should not be created in an unsecured schema where all users can create objects -
-                  'REVOKE CREATE ON SCHEMA % FROM public' to tighten security or comment out the DO block to disable the check$$, l_actual_schema;
-            END IF;
+        SELECT string_agg(safe_sp, ', ' ORDER BY rank) INTO l_secure_schemas_from_search_path FROM (
+           SELECT quote_ident(nspname) AS safe_sp, rank
+           FROM unnest(regexp_split_to_array(current_setting('search_path'), ',')) WITH ORDINALITY AS csp(schema_name, rank)
+                    JOIN pg_namespace n
+                         ON quote_ident(n.nspname) = CASE WHEN schema_name = '"$user"' THEN quote_ident(user) ELSE trim(schema_name) END
+           WHERE NOT has_schema_privilege('public', n.oid, 'CREATE')
+        ) x;
 
-            RAISE NOTICE '%', format($$ALTER FUNCTION get_stat_statements() SET search_path TO %s$$, l_actual_schema);
-            EXECUTE format($$ALTER FUNCTION get_stat_statements() SET search_path TO %s$$, l_actual_schema);
+        IF coalesce(l_secure_schemas_from_search_path, '') = '' THEN
+            RAISE NOTICE 'search_path = %', current_setting('search_path');
+            RAISE EXCEPTION $$get_stat_statements() SECURITY DEFINER helper will not be created as all schemas on search_path are unsecured where all users can create objects -
+              execute 'REVOKE CREATE ON SCHEMA $my_schema FROM public' to tighten security or comment out the DO block to disable the check$$;
+        ELSE
+            RAISE NOTICE '%', format($$ALTER FUNCTION get_stat_statements() SET search_path TO %s$$, l_secure_schemas_from_search_path);
+            EXECUTE format($$ALTER FUNCTION get_stat_statements() SET search_path TO %s$$, l_secure_schemas_from_search_path);
         END IF;
-    END
+    END;
 $SQL$;
 
 COMMIT;

--- a/pgwatch2/metrics/00_helpers/get_stat_statements/9.4/metric.sql
+++ b/pgwatch2/metrics/00_helpers/get_stat_statements/9.4/metric.sql
@@ -12,6 +12,8 @@ Usage not recommended for servers less than 9.2 (http://wiki.postgresql.org/wiki
 From v10 the "pg_monitor" system GRANT can be used for the same purpose so the wrapper is not actually needed then.
 */
 
+BEGIN;
+
 CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
 
 CREATE OR REPLACE FUNCTION get_stat_statements() RETURNS SETOF pg_stat_statements AS
@@ -27,3 +29,22 @@ $$ LANGUAGE sql VOLATILE SECURITY DEFINER;
 
 GRANT EXECUTE ON FUNCTION get_stat_statements() TO pgwatch2;
 COMMENT ON FUNCTION get_stat_statements() IS 'created for pgwatch2';
+
+DO $SQL$
+    DECLARE
+        l_actual_schema text;
+    BEGIN
+        SELECT n.nspname INTO l_actual_schema FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE proname = 'get_stat_statements';
+        IF FOUND THEN
+            IF has_schema_privilege('public', l_actual_schema, 'CREATE') THEN
+                RAISE EXCEPTION $$get_stat_statements() helper should not be created in an unsecured schema where all users can create objects -
+                  'REVOKE CREATE ON SCHEMA % FROM public' to tighten security or comment out the DO block to disable the check$$, l_actual_schema;
+            END IF;
+
+            RAISE NOTICE '%', format($$ALTER FUNCTION get_stat_statements() SET search_path TO %s$$, l_actual_schema);
+            EXECUTE format($$ALTER FUNCTION get_stat_statements() SET search_path TO %s$$, l_actual_schema);
+        END IF;
+    END
+$SQL$;
+
+COMMIT;

--- a/pgwatch2/metrics/00_helpers/get_stat_statements/9.4/metric.sql
+++ b/pgwatch2/metrics/00_helpers/get_stat_statements/9.4/metric.sql
@@ -30,21 +30,28 @@ $$ LANGUAGE sql VOLATILE SECURITY DEFINER;
 GRANT EXECUTE ON FUNCTION get_stat_statements() TO pgwatch2;
 COMMENT ON FUNCTION get_stat_statements() IS 'created for pgwatch2';
 
+-- below routine fixes function search_path to only include "more secure" schemas with no "public" CREATE privileges
 DO $SQL$
     DECLARE
-        l_actual_schema text;
+        l_secure_schemas_from_search_path text;
     BEGIN
-        SELECT n.nspname INTO l_actual_schema FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE proname = 'get_stat_statements';
-        IF FOUND THEN
-            IF has_schema_privilege('public', l_actual_schema, 'CREATE') THEN
-                RAISE EXCEPTION $$get_stat_statements() helper should not be created in an unsecured schema where all users can create objects -
-                  'REVOKE CREATE ON SCHEMA % FROM public' to tighten security or comment out the DO block to disable the check$$, l_actual_schema;
-            END IF;
+        SELECT string_agg(safe_sp, ', ' ORDER BY rank) INTO l_secure_schemas_from_search_path FROM (
+           SELECT quote_ident(nspname) AS safe_sp, rank
+           FROM unnest(regexp_split_to_array(current_setting('search_path'), ',')) WITH ORDINALITY AS csp(schema_name, rank)
+                    JOIN pg_namespace n
+                         ON quote_ident(n.nspname) = CASE WHEN schema_name = '"$user"' THEN quote_ident(user) ELSE trim(schema_name) END
+           WHERE NOT has_schema_privilege('public', n.oid, 'CREATE')
+        ) x;
 
-            RAISE NOTICE '%', format($$ALTER FUNCTION get_stat_statements() SET search_path TO %s$$, l_actual_schema);
-            EXECUTE format($$ALTER FUNCTION get_stat_statements() SET search_path TO %s$$, l_actual_schema);
+        IF coalesce(l_secure_schemas_from_search_path, '') = '' THEN
+            RAISE NOTICE 'search_path = %', current_setting('search_path');
+            RAISE EXCEPTION $$get_stat_statements() SECURITY DEFINER helper will not be created as all schemas on search_path are unsecured where all users can create objects -
+              execute 'REVOKE CREATE ON SCHEMA $my_schema FROM public' to tighten security or comment out the DO block to disable the check$$;
+        ELSE
+            RAISE NOTICE '%', format($$ALTER FUNCTION get_stat_statements() SET search_path TO %s$$, l_secure_schemas_from_search_path);
+            EXECUTE format($$ALTER FUNCTION get_stat_statements() SET search_path TO %s$$, l_secure_schemas_from_search_path);
         END IF;
-    END
+    END;
 $SQL$;
 
 COMMIT;

--- a/pgwatch2/metrics/00_helpers/get_table_bloat_approx/9.5/metric.sql
+++ b/pgwatch2/metrics/00_helpers/get_table_bloat_approx/9.5/metric.sql
@@ -22,21 +22,28 @@ $$
       and not n.nspname like any (array[E'pg\\_%', 'information_schema'])
 $$ LANGUAGE sql SECURITY DEFINER;
 
+-- below routine fixes function search_path to only include "more secure" schemas with no "public" CREATE privileges
 DO $SQL$
     DECLARE
-        l_actual_schema text;
+        l_secure_schemas_from_search_path text;
     BEGIN
-        SELECT n.nspname INTO l_actual_schema FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE proname = 'get_table_bloat_approx';
-        IF FOUND THEN
-            IF has_schema_privilege('public', l_actual_schema, 'CREATE') THEN
-                RAISE EXCEPTION $$get_table_bloat_approx() helper should not be created in an unsecured schema where all users can create objects -
-                  'REVOKE CREATE ON SCHEMA % FROM public' to tighten security or comment out the DO block to disable the check$$, l_actual_schema;
-            END IF;
+        SELECT string_agg(safe_sp, ', ' ORDER BY rank) INTO l_secure_schemas_from_search_path FROM (
+           SELECT quote_ident(nspname) AS safe_sp, rank
+           FROM unnest(regexp_split_to_array(current_setting('search_path'), ',')) WITH ORDINALITY AS csp(schema_name, rank)
+                    JOIN pg_namespace n
+                         ON quote_ident(n.nspname) = CASE WHEN schema_name = '"$user"' THEN quote_ident(user) ELSE trim(schema_name) END
+           WHERE NOT has_schema_privilege('public', n.oid, 'CREATE')
+        ) x;
 
-            RAISE NOTICE '%', format($$ALTER FUNCTION get_table_bloat_approx() SET search_path TO %s$$, l_actual_schema);
-            EXECUTE format($$ALTER FUNCTION get_table_bloat_approx() SET search_path TO %s$$, l_actual_schema);
+        IF coalesce(l_secure_schemas_from_search_path, '') = '' THEN
+            RAISE NOTICE 'search_path = %', current_setting('search_path');
+            RAISE EXCEPTION $$get_table_bloat_approx() SECURITY DEFINER helper will not be created as all schemas on search_path are unsecured where all users can create objects -
+              execute 'REVOKE CREATE ON SCHEMA $my_schema FROM public' to tighten security or comment out the DO block to disable the check$$;
+        ELSE
+            RAISE NOTICE '%', format($$ALTER FUNCTION get_table_bloat_approx() SET search_path TO %s$$, l_secure_schemas_from_search_path);
+            EXECUTE format($$ALTER FUNCTION get_table_bloat_approx() SET search_path TO %s$$, l_secure_schemas_from_search_path);
         END IF;
-    END
+    END;
 $SQL$;
 
 COMMIT;

--- a/pgwatch2/metrics/00_helpers/get_table_bloat_approx_sql/12/metric.sql
+++ b/pgwatch2/metrics/00_helpers/get_table_bloat_approx_sql/12/metric.sql
@@ -1,5 +1,6 @@
 -- small modifications to SQL from https://github.com/ioguix/pgsql-bloat-estimation
 -- NB! monitoring user needs SELECT grant on all tables or a SECURITY DEFINER wrapper around that SQL
+BEGIN;
 
 CREATE OR REPLACE FUNCTION get_table_bloat_approx_sql(
       OUT full_table_name text,
@@ -126,3 +127,22 @@ $$;
 
 GRANT EXECUTE ON FUNCTION get_table_bloat_approx_sql() TO pgwatch2;
 COMMENT ON FUNCTION get_table_bloat_approx_sql() is 'created for pgwatch2';
+
+DO $SQL$
+    DECLARE
+        l_actual_schema text;
+    BEGIN
+        SELECT n.nspname INTO l_actual_schema FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE proname = 'get_table_bloat_approx_sql';
+        IF FOUND THEN
+            IF has_schema_privilege('public', l_actual_schema, 'CREATE') THEN
+                RAISE EXCEPTION $$get_table_bloat_approx_sql() helper should not be created in an unsecured schema where all users can create objects -
+                  'REVOKE CREATE ON SCHEMA public FROM public' to tighten security or comment out the DO block to disable the check$$;
+            END IF;
+
+            RAISE NOTICE '%', format($$ALTER FUNCTION get_table_bloat_approx_sql() SET search_path TO %s$$, l_actual_schema);
+            EXECUTE format($$ALTER FUNCTION get_table_bloat_approx_sql() SET search_path TO %s$$, l_actual_schema);
+        END IF;
+    END
+$SQL$;
+
+COMMIT;

--- a/pgwatch2/metrics/00_helpers/get_table_bloat_approx_sql/12/metric.sql
+++ b/pgwatch2/metrics/00_helpers/get_table_bloat_approx_sql/12/metric.sql
@@ -128,21 +128,28 @@ $$;
 GRANT EXECUTE ON FUNCTION get_table_bloat_approx_sql() TO pgwatch2;
 COMMENT ON FUNCTION get_table_bloat_approx_sql() is 'created for pgwatch2';
 
+-- below routine fixes function search_path to only include "more secure" schemas with no "public" CREATE privileges
 DO $SQL$
     DECLARE
-        l_actual_schema text;
+        l_secure_schemas_from_search_path text;
     BEGIN
-        SELECT n.nspname INTO l_actual_schema FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE proname = 'get_table_bloat_approx_sql';
-        IF FOUND THEN
-            IF has_schema_privilege('public', l_actual_schema, 'CREATE') THEN
-                RAISE EXCEPTION $$get_table_bloat_approx_sql() helper should not be created in an unsecured schema where all users can create objects -
-                  'REVOKE CREATE ON SCHEMA public FROM public' to tighten security or comment out the DO block to disable the check$$;
-            END IF;
+        SELECT string_agg(safe_sp, ', ' ORDER BY rank) INTO l_secure_schemas_from_search_path FROM (
+           SELECT quote_ident(nspname) AS safe_sp, rank
+           FROM unnest(regexp_split_to_array(current_setting('search_path'), ',')) WITH ORDINALITY AS csp(schema_name, rank)
+                    JOIN pg_namespace n
+                         ON quote_ident(n.nspname) = CASE WHEN schema_name = '"$user"' THEN quote_ident(user) ELSE trim(schema_name) END
+           WHERE NOT has_schema_privilege('public', n.oid, 'CREATE')
+        ) x;
 
-            RAISE NOTICE '%', format($$ALTER FUNCTION get_table_bloat_approx_sql() SET search_path TO %s$$, l_actual_schema);
-            EXECUTE format($$ALTER FUNCTION get_table_bloat_approx_sql() SET search_path TO %s$$, l_actual_schema);
+        IF coalesce(l_secure_schemas_from_search_path, '') = '' THEN
+            RAISE NOTICE 'search_path = %', current_setting('search_path');
+            RAISE EXCEPTION $$get_table_bloat_approx_sql() SECURITY DEFINER helper will not be created as all schemas on search_path are unsecured where all users can create objects -
+              execute 'REVOKE CREATE ON SCHEMA $my_schema FROM public' to tighten security or comment out the DO block to disable the check$$;
+        ELSE
+            RAISE NOTICE '%', format($$ALTER FUNCTION get_table_bloat_approx_sql() SET search_path TO %s$$, l_secure_schemas_from_search_path);
+            EXECUTE format($$ALTER FUNCTION get_table_bloat_approx_sql() SET search_path TO %s$$, l_secure_schemas_from_search_path);
         END IF;
-    END
+    END;
 $SQL$;
 
 COMMIT;

--- a/pgwatch2/metrics/00_helpers/get_table_bloat_approx_sql/9.0/metric.sql
+++ b/pgwatch2/metrics/00_helpers/get_table_bloat_approx_sql/9.0/metric.sql
@@ -129,21 +129,28 @@ $$;
 GRANT EXECUTE ON FUNCTION get_table_bloat_approx_sql() TO pgwatch2;
 COMMENT ON FUNCTION get_table_bloat_approx_sql() is 'created for pgwatch2';
 
+-- below routine fixes function search_path to only include "more secure" schemas with no "public" CREATE privileges
 DO $SQL$
     DECLARE
-        l_actual_schema text;
+        l_secure_schemas_from_search_path text;
     BEGIN
-        SELECT n.nspname INTO l_actual_schema FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE proname = 'get_table_bloat_approx_sql';
-        IF FOUND THEN
-            IF has_schema_privilege('public', l_actual_schema, 'CREATE') THEN
-                RAISE EXCEPTION $$get_table_bloat_approx_sql() helper should not be created in an unsecured schema where all users can create objects -
-                  'REVOKE CREATE ON SCHEMA % FROM public' to tighten security or comment out the DO block to disable the check$$, l_actual_schema;
-            END IF;
+        SELECT string_agg(safe_sp, ', ' ORDER BY rank) INTO l_secure_schemas_from_search_path FROM (
+           SELECT quote_ident(nspname) AS safe_sp, rank
+           FROM unnest(regexp_split_to_array(current_setting('search_path'), ',')) WITH ORDINALITY AS csp(schema_name, rank)
+                    JOIN pg_namespace n
+                         ON quote_ident(n.nspname) = CASE WHEN schema_name = '"$user"' THEN quote_ident(user) ELSE trim(schema_name) END
+           WHERE NOT has_schema_privilege('public', n.oid, 'CREATE')
+        ) x;
 
-            RAISE NOTICE '%', format($$ALTER FUNCTION get_table_bloat_approx_sql() SET search_path TO %s$$, l_actual_schema);
-            EXECUTE format($$ALTER FUNCTION get_table_bloat_approx_sql() SET search_path TO %s$$, l_actual_schema);
+        IF coalesce(l_secure_schemas_from_search_path, '') = '' THEN
+            RAISE NOTICE 'search_path = %', current_setting('search_path');
+            RAISE EXCEPTION $$get_table_bloat_approx_sql() SECURITY DEFINER helper will not be created as all schemas on search_path are unsecured where all users can create objects -
+              execute 'REVOKE CREATE ON SCHEMA $my_schema FROM public' to tighten security or comment out the DO block to disable the check$$;
+        ELSE
+            RAISE NOTICE '%', format($$ALTER FUNCTION get_table_bloat_approx_sql() SET search_path TO %s$$, l_secure_schemas_from_search_path);
+            EXECUTE format($$ALTER FUNCTION get_table_bloat_approx_sql() SET search_path TO %s$$, l_secure_schemas_from_search_path);
         END IF;
-    END
+    END;
 $SQL$;
 
 COMMIT;

--- a/pgwatch2/sql/config_store/metric_definitions.sql
+++ b/pgwatch2/sql/config_store/metric_definitions.sql
@@ -3277,21 +3277,28 @@ $$ LANGUAGE sql SECURITY DEFINER;
 GRANT EXECUTE ON FUNCTION get_table_bloat_approx() TO pgwatch2;
 COMMENT ON FUNCTION get_table_bloat_approx() is 'created for pgwatch2';
 
+-- below routine fixes function search_path to only include "more secure" schemas with no "public" CREATE privileges
 DO $_$
     DECLARE
-        l_actual_schema text;
+        l_secure_schemas_from_search_path text;
     BEGIN
-        SELECT n.nspname INTO l_actual_schema FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE proname = 'get_table_bloat_approx';
-        IF FOUND THEN
-            IF has_schema_privilege('public', l_actual_schema, 'CREATE') THEN
-                RAISE EXCEPTION $$get_table_bloat_approx() helper should not be created in an unsecured schema where all users can create objects -
-                  'REVOKE CREATE ON SCHEMA % FROM public' to tighten security or comment out the DO block to disable the check$$, l_actual_schema;
-            END IF;
+        SELECT string_agg(safe_sp, ', ' ORDER BY rank) INTO l_secure_schemas_from_search_path FROM (
+           SELECT quote_ident(nspname) AS safe_sp, rank
+           FROM unnest(regexp_split_to_array(current_setting('search_path'), ',')) WITH ORDINALITY AS csp(schema_name, rank)
+                    JOIN pg_namespace n
+                         ON quote_ident(n.nspname) = CASE WHEN schema_name = '"$user"' THEN quote_ident(user) ELSE trim(schema_name) END
+           WHERE NOT has_schema_privilege('public', n.oid, 'CREATE')
+        ) x;
 
-            RAISE NOTICE '%', format($$ALTER FUNCTION get_table_bloat_approx() SET search_path TO %s$$, l_actual_schema);
-            EXECUTE format($$ALTER FUNCTION get_table_bloat_approx() SET search_path TO %s$$, l_actual_schema);
+        IF coalesce(l_secure_schemas_from_search_path, '') = '' THEN
+            RAISE NOTICE 'search_path = %', current_setting('search_path');
+            RAISE EXCEPTION $$get_table_bloat_approx() SECURITY DEFINER helper will not be created as all schemas on search_path are unsecured where all users can create objects -
+              execute 'REVOKE CREATE ON SCHEMA $my_schema FROM public' to tighten security or comment out the DO block to disable the check$$;
+        ELSE
+            RAISE NOTICE '%', format($$ALTER FUNCTION get_table_bloat_approx() SET search_path TO %s$$, l_secure_schemas_from_search_path);
+            EXECUTE format($$ALTER FUNCTION get_table_bloat_approx() SET search_path TO %s$$, l_secure_schemas_from_search_path);
         END IF;
-    END
+    END;
 $_$;
 
 COMMIT;
@@ -3436,21 +3443,28 @@ $$;
 GRANT EXECUTE ON FUNCTION get_table_bloat_approx_sql() TO pgwatch2;
 COMMENT ON FUNCTION get_table_bloat_approx_sql() is 'created for pgwatch2';
 
+-- below routine fixes function search_path to only include "more secure" schemas with no "public" CREATE privileges
 DO $_$
     DECLARE
-        l_actual_schema text;
+        l_secure_schemas_from_search_path text;
     BEGIN
-        SELECT n.nspname INTO l_actual_schema FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE proname = 'get_table_bloat_approx_sql';
-        IF FOUND THEN
-            IF has_schema_privilege('public', l_actual_schema, 'CREATE') THEN
-                RAISE EXCEPTION $$get_table_bloat_approx_sql() helper should not be created in an unsecured schema where all users can create objects -
-                  'REVOKE CREATE ON SCHEMA % FROM public' to tighten security or comment out the DO block to disable the check$$, l_actual_schema;
-            END IF;
+        SELECT string_agg(safe_sp, ', ' ORDER BY rank) INTO l_secure_schemas_from_search_path FROM (
+           SELECT quote_ident(nspname) AS safe_sp, rank
+           FROM unnest(regexp_split_to_array(current_setting('search_path'), ',')) WITH ORDINALITY AS csp(schema_name, rank)
+                    JOIN pg_namespace n
+                         ON quote_ident(n.nspname) = CASE WHEN schema_name = '"$user"' THEN quote_ident(user) ELSE trim(schema_name) END
+           WHERE NOT has_schema_privilege('public', n.oid, 'CREATE')
+        ) x;
 
-            RAISE NOTICE '%', format($$ALTER FUNCTION get_table_bloat_approx_sql() SET search_path TO %s$$, l_actual_schema);
-            EXECUTE format($$ALTER FUNCTION get_table_bloat_approx_sql() SET search_path TO %s$$, l_actual_schema);
+        IF coalesce(l_secure_schemas_from_search_path, '') = '' THEN
+            RAISE NOTICE 'search_path = %', current_setting('search_path');
+            RAISE EXCEPTION $$get_table_bloat_approx_sql() SECURITY DEFINER helper will not be created as all schemas on search_path are unsecured where all users can create objects -
+              execute 'REVOKE CREATE ON SCHEMA $my_schema FROM public' to tighten security or comment out the DO block to disable the check$$;
+        ELSE
+            RAISE NOTICE '%', format($$ALTER FUNCTION get_table_bloat_approx_sql() SET search_path TO %s$$, l_secure_schemas_from_search_path);
+            EXECUTE format($$ALTER FUNCTION get_table_bloat_approx_sql() SET search_path TO %s$$, l_secure_schemas_from_search_path);
         END IF;
-    END
+    END;
 $_$;
 
 COMMIT;
@@ -3594,21 +3608,28 @@ $$;
 GRANT EXECUTE ON FUNCTION get_table_bloat_approx_sql() TO pgwatch2;
 COMMENT ON FUNCTION get_table_bloat_approx_sql() is 'created for pgwatch2';
 
+-- below routine fixes function search_path to only include "more secure" schemas with no "public" CREATE privileges
 DO $_$
     DECLARE
-        l_actual_schema text;
+        l_secure_schemas_from_search_path text;
     BEGIN
-        SELECT n.nspname INTO l_actual_schema FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE proname = 'get_table_bloat_approx_sql';
-        IF FOUND THEN
-            IF has_schema_privilege('public', l_actual_schema, 'CREATE') THEN
-                RAISE EXCEPTION $$get_table_bloat_approx_sql() helper should not be created in an unsecured schema where all users can create objects -
-                  'REVOKE CREATE ON SCHEMA % FROM public' to tighten security or comment out the DO block to disable the check$$, l_actual_schema;
-            END IF;
+        SELECT string_agg(safe_sp, ', ' ORDER BY rank) INTO l_secure_schemas_from_search_path FROM (
+           SELECT quote_ident(nspname) AS safe_sp, rank
+           FROM unnest(regexp_split_to_array(current_setting('search_path'), ',')) WITH ORDINALITY AS csp(schema_name, rank)
+                    JOIN pg_namespace n
+                         ON quote_ident(n.nspname) = CASE WHEN schema_name = '"$user"' THEN quote_ident(user) ELSE trim(schema_name) END
+           WHERE NOT has_schema_privilege('public', n.oid, 'CREATE')
+        ) x;
 
-            RAISE NOTICE '%', format($$ALTER FUNCTION get_table_bloat_approx_sql() SET search_path TO %s$$, l_actual_schema);
-            EXECUTE format($$ALTER FUNCTION get_table_bloat_approx_sql() SET search_path TO %s$$, l_actual_schema);
+        IF coalesce(l_secure_schemas_from_search_path, '') = '' THEN
+            RAISE NOTICE 'search_path = %', current_setting('search_path');
+            RAISE EXCEPTION $$get_table_bloat_approx_sql() SECURITY DEFINER helper will not be created as all schemas on search_path are unsecured where all users can create objects -
+              execute 'REVOKE CREATE ON SCHEMA $my_schema FROM public' to tighten security or comment out the DO block to disable the check$$;
+        ELSE
+            RAISE NOTICE '%', format($$ALTER FUNCTION get_table_bloat_approx_sql() SET search_path TO %s$$, l_secure_schemas_from_search_path);
+            EXECUTE format($$ALTER FUNCTION get_table_bloat_approx_sql() SET search_path TO %s$$, l_secure_schemas_from_search_path);
         END IF;
-    END
+    END;
 $_$;
 
 COMMIT;
@@ -4423,21 +4444,28 @@ GRANT EXECUTE ON FUNCTION get_load_average_copy() TO pgwatch2;
 
 COMMENT ON FUNCTION get_load_average_copy() is 'created for pgwatch2';
 
+-- below routine fixes function search_path to only include "more secure" schemas with no "public" CREATE privileges
 DO $_$
     DECLARE
-        l_actual_schema text;
+        l_secure_schemas_from_search_path text;
     BEGIN
-        SELECT n.nspname INTO l_actual_schema FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE proname = 'get_load_average_copy';
-        IF FOUND THEN
-            IF has_schema_privilege('public', l_actual_schema, 'CREATE') THEN
-                RAISE EXCEPTION $$get_load_average_copy() helper should not be created in an unsecured schema where all users can create objects -
-                  'REVOKE CREATE ON SCHEMA % FROM public' to tighten security or comment out the DO block to disable the check$$, l_actual_schema;
-            END IF;
+        SELECT string_agg(safe_sp, ', ' ORDER BY rank) INTO l_secure_schemas_from_search_path FROM (
+           SELECT quote_ident(nspname) AS safe_sp, rank
+           FROM unnest(regexp_split_to_array(current_setting('search_path'), ',')) WITH ORDINALITY AS csp(schema_name, rank)
+                    JOIN pg_namespace n
+                         ON quote_ident(n.nspname) = CASE WHEN schema_name = '"$user"' THEN quote_ident(user) ELSE trim(schema_name) END
+           WHERE NOT has_schema_privilege('public', n.oid, 'CREATE')
+        ) x;
 
-            RAISE NOTICE '%', format($$ALTER FUNCTION get_load_average_copy() SET search_path TO %s$$, l_actual_schema);
-            EXECUTE format($$ALTER FUNCTION get_load_average_copy() SET search_path TO %s$$, l_actual_schema);
+        IF coalesce(l_secure_schemas_from_search_path, '') = '' THEN
+            RAISE NOTICE 'search_path = %', current_setting('search_path');
+            RAISE EXCEPTION $$get_load_average_copy() SECURITY DEFINER helper will not be created as all schemas on search_path are unsecured where all users can create objects -
+              execute 'REVOKE CREATE ON SCHEMA $my_schema FROM public' to tighten security or comment out the DO block to disable the check$$;
+        ELSE
+            RAISE NOTICE '%', format($$ALTER FUNCTION get_load_average_copy() SET search_path TO %s$$, l_secure_schemas_from_search_path);
+            EXECUTE format($$ALTER FUNCTION get_load_average_copy() SET search_path TO %s$$, l_secure_schemas_from_search_path);
         END IF;
-    END
+    END;
 $_$;
 
 COMMIT;
@@ -4550,21 +4578,28 @@ $$ LANGUAGE sql VOLATILE SECURITY DEFINER;
 GRANT EXECUTE ON FUNCTION get_stat_statements() TO pgwatch2;
 COMMENT ON FUNCTION get_stat_statements() IS 'created for pgwatch2';
 
+-- below routine fixes function search_path to only include "more secure" schemas with no "public" CREATE privileges
 DO $_$
     DECLARE
-        l_actual_schema text;
+        l_secure_schemas_from_search_path text;
     BEGIN
-        SELECT n.nspname INTO l_actual_schema FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE proname = 'get_stat_statements';
-        IF FOUND THEN
-            IF has_schema_privilege('public', l_actual_schema, 'CREATE') THEN
-                RAISE EXCEPTION $$get_stat_statements() helpers should not be created in an unsecured schema where all users can create objects -
-                  'REVOKE CREATE ON SCHEMA % FROM public' to tighten security or comment out the DO block to disable the check$$, l_actual_schema;
-            END IF;
+        SELECT string_agg(safe_sp, ', ' ORDER BY rank) INTO l_secure_schemas_from_search_path FROM (
+           SELECT quote_ident(nspname) AS safe_sp, rank
+           FROM unnest(regexp_split_to_array(current_setting('search_path'), ',')) WITH ORDINALITY AS csp(schema_name, rank)
+                    JOIN pg_namespace n
+                         ON quote_ident(n.nspname) = CASE WHEN schema_name = '"$user"' THEN quote_ident(user) ELSE trim(schema_name) END
+           WHERE NOT has_schema_privilege('public', n.oid, 'CREATE')
+        ) x;
 
-            RAISE NOTICE '%', format($$ALTER FUNCTION get_stat_statements() SET search_path TO %s$$, l_actual_schema);
-            EXECUTE format($$ALTER FUNCTION get_stat_statements() SET search_path TO %s$$, l_actual_schema);
+        IF coalesce(l_secure_schemas_from_search_path, '') = '' THEN
+            RAISE NOTICE 'search_path = %', current_setting('search_path');
+            RAISE EXCEPTION $$get_stat_statements() SECURITY DEFINER helper will not be created as all schemas on search_path are unsecured where all users can create objects -
+              execute 'REVOKE CREATE ON SCHEMA $my_schema FROM public' to tighten security or comment out the DO block to disable the check$$;
+        ELSE
+            RAISE NOTICE '%', format($$ALTER FUNCTION get_stat_statements() SET search_path TO %s$$, l_secure_schemas_from_search_path);
+            EXECUTE format($$ALTER FUNCTION get_stat_statements() SET search_path TO %s$$, l_secure_schemas_from_search_path);
         END IF;
-    END
+    END;
 $_$;
 
 COMMIT;
@@ -4598,22 +4633,29 @@ $$ LANGUAGE sql VOLATILE SECURITY DEFINER;
 GRANT EXECUTE ON FUNCTION get_stat_statements() TO pgwatch2;
 COMMENT ON FUNCTION get_stat_statements() IS 'created for pgwatch2';
 
-DO $SQL$
+-- below routine fixes function search_path to only include "more secure" schemas with no "public" CREATE privileges
+DO $_$
     DECLARE
-        l_actual_schema text;
+        l_secure_schemas_from_search_path text;
     BEGIN
-        SELECT n.nspname INTO l_actual_schema FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE proname = 'get_stat_statements';
-        IF FOUND THEN
-            IF has_schema_privilege('public', l_actual_schema, 'CREATE') THEN
-                RAISE EXCEPTION $$get_stat_statements() helper should not be created in an unsecured schema where all users can create objects -
-                  'REVOKE CREATE ON SCHEMA % FROM public' to tighten security or comment out the DO block to disable the check$$, l_actual_schema;
-            END IF;
+        SELECT string_agg(safe_sp, ', ' ORDER BY rank) INTO l_secure_schemas_from_search_path FROM (
+           SELECT quote_ident(nspname) AS safe_sp, rank
+           FROM unnest(regexp_split_to_array(current_setting('search_path'), ',')) WITH ORDINALITY AS csp(schema_name, rank)
+                    JOIN pg_namespace n
+                         ON quote_ident(n.nspname) = CASE WHEN schema_name = '"$user"' THEN quote_ident(user) ELSE trim(schema_name) END
+           WHERE NOT has_schema_privilege('public', n.oid, 'CREATE')
+        ) x;
 
-            RAISE NOTICE '%', format($$ALTER FUNCTION get_stat_statements() SET search_path TO %s$$, l_actual_schema);
-            EXECUTE format($$ALTER FUNCTION get_stat_statements() SET search_path TO %s$$, l_actual_schema);
+        IF coalesce(l_secure_schemas_from_search_path, '') = '' THEN
+            RAISE NOTICE 'search_path = %', current_setting('search_path');
+            RAISE EXCEPTION $$get_stat_statements() SECURITY DEFINER helper will not be created as all schemas on search_path are unsecured where all users can create objects -
+              execute 'REVOKE CREATE ON SCHEMA $my_schema FROM public' to tighten security or comment out the DO block to disable the check$$;
+        ELSE
+            RAISE NOTICE '%', format($$ALTER FUNCTION get_stat_statements() SET search_path TO %s$$, l_secure_schemas_from_search_path);
+            EXECUTE format($$ALTER FUNCTION get_stat_statements() SET search_path TO %s$$, l_secure_schemas_from_search_path);
         END IF;
-    END
-$SQL$;
+    END;
+$_$;
 
 COMMIT;
 $sql$,

--- a/pgwatch2/sql/config_store/metric_definitions.sql
+++ b/pgwatch2/sql/config_store/metric_definitions.sql
@@ -3277,6 +3277,23 @@ $$ LANGUAGE sql SECURITY DEFINER;
 GRANT EXECUTE ON FUNCTION get_table_bloat_approx() TO pgwatch2;
 COMMENT ON FUNCTION get_table_bloat_approx() is 'created for pgwatch2';
 
+DO $_$
+    DECLARE
+        l_actual_schema text;
+    BEGIN
+        SELECT n.nspname INTO l_actual_schema FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE proname = 'get_table_bloat_approx';
+        IF FOUND THEN
+            IF has_schema_privilege('public', l_actual_schema, 'CREATE') THEN
+                RAISE EXCEPTION $$get_table_bloat_approx() helper should not be created in an unsecured schema where all users can create objects -
+                  'REVOKE CREATE ON SCHEMA % FROM public' to tighten security or comment out the DO block to disable the check$$, l_actual_schema;
+            END IF;
+
+            RAISE NOTICE '%', format($$ALTER FUNCTION get_table_bloat_approx() SET search_path TO %s$$, l_actual_schema);
+            EXECUTE format($$ALTER FUNCTION get_table_bloat_approx() SET search_path TO %s$$, l_actual_schema);
+        END IF;
+    END
+$_$;
+
 COMMIT;
 $sql$,
 'for internal usage - when connecting user is marked as superuser then the daemon will automatically try to create the needed helpers on the monitored db',
@@ -3290,6 +3307,8 @@ values (
 $sql$
 -- small modifications to SQL from https://github.com/ioguix/pgsql-bloat-estimation
 -- NB! monitoring user needs SELECT grant on all tables or a SECURITY DEFINER wrapper around that SQL
+
+BEGIN;
 
 CREATE OR REPLACE FUNCTION get_table_bloat_approx_sql(
       OUT full_table_name text,
@@ -3417,6 +3436,24 @@ $$;
 GRANT EXECUTE ON FUNCTION get_table_bloat_approx_sql() TO pgwatch2;
 COMMENT ON FUNCTION get_table_bloat_approx_sql() is 'created for pgwatch2';
 
+DO $_$
+    DECLARE
+        l_actual_schema text;
+    BEGIN
+        SELECT n.nspname INTO l_actual_schema FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE proname = 'get_table_bloat_approx_sql';
+        IF FOUND THEN
+            IF has_schema_privilege('public', l_actual_schema, 'CREATE') THEN
+                RAISE EXCEPTION $$get_table_bloat_approx_sql() helper should not be created in an unsecured schema where all users can create objects -
+                  'REVOKE CREATE ON SCHEMA % FROM public' to tighten security or comment out the DO block to disable the check$$, l_actual_schema;
+            END IF;
+
+            RAISE NOTICE '%', format($$ALTER FUNCTION get_table_bloat_approx_sql() SET search_path TO %s$$, l_actual_schema);
+            EXECUTE format($$ALTER FUNCTION get_table_bloat_approx_sql() SET search_path TO %s$$, l_actual_schema);
+        END IF;
+    END
+$_$;
+
+COMMIT;
 $sql$,
 true
 );
@@ -3428,6 +3465,8 @@ values (
 $sql$
 -- small modifications to SQL from https://github.com/ioguix/pgsql-bloat-estimation
 -- NB! monitoring user needs SELECT grant on all tables or a SECURITY DEFINER wrapper around that SQL
+
+BEGIN;
 
 CREATE OR REPLACE FUNCTION get_table_bloat_approx_sql(
       OUT full_table_name text,
@@ -3555,6 +3594,24 @@ $$;
 GRANT EXECUTE ON FUNCTION get_table_bloat_approx_sql() TO pgwatch2;
 COMMENT ON FUNCTION get_table_bloat_approx_sql() is 'created for pgwatch2';
 
+DO $_$
+    DECLARE
+        l_actual_schema text;
+    BEGIN
+        SELECT n.nspname INTO l_actual_schema FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE proname = 'get_table_bloat_approx_sql';
+        IF FOUND THEN
+            IF has_schema_privilege('public', l_actual_schema, 'CREATE') THEN
+                RAISE EXCEPTION $$get_table_bloat_approx_sql() helper should not be created in an unsecured schema where all users can create objects -
+                  'REVOKE CREATE ON SCHEMA % FROM public' to tighten security or comment out the DO block to disable the check$$, l_actual_schema;
+            END IF;
+
+            RAISE NOTICE '%', format($$ALTER FUNCTION get_table_bloat_approx_sql() SET search_path TO %s$$, l_actual_schema);
+            EXECUTE format($$ALTER FUNCTION get_table_bloat_approx_sql() SET search_path TO %s$$, l_actual_schema);
+        END IF;
+    END
+$_$;
+
+COMMIT;
 $sql$,
 true
 );
@@ -4366,6 +4423,23 @@ GRANT EXECUTE ON FUNCTION get_load_average_copy() TO pgwatch2;
 
 COMMENT ON FUNCTION get_load_average_copy() is 'created for pgwatch2';
 
+DO $_$
+    DECLARE
+        l_actual_schema text;
+    BEGIN
+        SELECT n.nspname INTO l_actual_schema FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE proname = 'get_load_average_copy';
+        IF FOUND THEN
+            IF has_schema_privilege('public', l_actual_schema, 'CREATE') THEN
+                RAISE EXCEPTION $$get_load_average_copy() helper should not be created in an unsecured schema where all users can create objects -
+                  'REVOKE CREATE ON SCHEMA % FROM public' to tighten security or comment out the DO block to disable the check$$, l_actual_schema;
+            END IF;
+
+            RAISE NOTICE '%', format($$ALTER FUNCTION get_load_average_copy() SET search_path TO %s$$, l_actual_schema);
+            EXECUTE format($$ALTER FUNCTION get_load_average_copy() SET search_path TO %s$$, l_actual_schema);
+        END IF;
+    END
+$_$;
+
 COMMIT;
 $sql$,
 'for internal usage - when connecting user is marked as superuser then the daemon will automatically try to create the needed helpers on the monitored db',
@@ -4449,6 +4523,8 @@ values (
 'get_stat_statements',
 9.2,
 $sql$
+BEGIN;
+
 CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
 
 CREATE OR REPLACE FUNCTION get_stat_statements() RETURNS TABLE (
@@ -4474,6 +4550,24 @@ $$ LANGUAGE sql VOLATILE SECURITY DEFINER;
 GRANT EXECUTE ON FUNCTION get_stat_statements() TO pgwatch2;
 COMMENT ON FUNCTION get_stat_statements() IS 'created for pgwatch2';
 
+DO $_$
+    DECLARE
+        l_actual_schema text;
+    BEGIN
+        SELECT n.nspname INTO l_actual_schema FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE proname = 'get_stat_statements';
+        IF FOUND THEN
+            IF has_schema_privilege('public', l_actual_schema, 'CREATE') THEN
+                RAISE EXCEPTION $$get_stat_statements() helpers should not be created in an unsecured schema where all users can create objects -
+                  'REVOKE CREATE ON SCHEMA % FROM public' to tighten security or comment out the DO block to disable the check$$, l_actual_schema;
+            END IF;
+
+            RAISE NOTICE '%', format($$ALTER FUNCTION get_stat_statements() SET search_path TO %s$$, l_actual_schema);
+            EXECUTE format($$ALTER FUNCTION get_stat_statements() SET search_path TO %s$$, l_actual_schema);
+        END IF;
+    END
+$_$;
+
+COMMIT;
 $sql$,
 'for internal usage - when connecting user is marked as superuser then the daemon will automatically try to create the needed helpers on the monitored db',
 true
@@ -4486,6 +4580,8 @@ values (
 'get_stat_statements',
 9.4,
 $sql$
+BEGIN;
+
 CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
 
 CREATE OR REPLACE FUNCTION get_stat_statements() RETURNS SETOF pg_stat_statements AS
@@ -4502,6 +4598,24 @@ $$ LANGUAGE sql VOLATILE SECURITY DEFINER;
 GRANT EXECUTE ON FUNCTION get_stat_statements() TO pgwatch2;
 COMMENT ON FUNCTION get_stat_statements() IS 'created for pgwatch2';
 
+DO $SQL$
+    DECLARE
+        l_actual_schema text;
+    BEGIN
+        SELECT n.nspname INTO l_actual_schema FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE proname = 'get_stat_statements';
+        IF FOUND THEN
+            IF has_schema_privilege('public', l_actual_schema, 'CREATE') THEN
+                RAISE EXCEPTION $$get_stat_statements() helper should not be created in an unsecured schema where all users can create objects -
+                  'REVOKE CREATE ON SCHEMA % FROM public' to tighten security or comment out the DO block to disable the check$$, l_actual_schema;
+            END IF;
+
+            RAISE NOTICE '%', format($$ALTER FUNCTION get_stat_statements() SET search_path TO %s$$, l_actual_schema);
+            EXECUTE format($$ALTER FUNCTION get_stat_statements() SET search_path TO %s$$, l_actual_schema);
+        END IF;
+    END
+$SQL$;
+
+COMMIT;
 $sql$,
 'for internal usage - when connecting user is marked as superuser then the daemon will automatically try to create the needed helpers on the monitored db',
 true


### PR DESCRIPTION
Fix "search_path" for those helpers that use some non-core views /
tables and error out when search_path has "public" CREATE privs