### PR TITLE
add pool to bgbouncer

### DIFF
--- a/pgwatch2/go.mod
+++ b/pgwatch2/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
 	github.com/prometheus/client_golang v1.7.1
 	github.com/samuel/go-zookeeper v0.0.0-20200724154423-2164a8ac840e
-	github.com/shirou/gopsutil/v3 v3.20.12 // indirect
+	github.com/shirou/gopsutil/v3 v3.20.12
 	github.com/shopspring/decimal v1.2.0
 	go.etcd.io/etcd v3.3.25+incompatible
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a

--- a/pgwatch2/metrics/pgbouncer_pools/0/metric.sql
+++ b/pgwatch2/metrics/pgbouncer_pools/0/metric.sql
@@ -1,0 +1,1 @@
+show pools

--- a/pgwatch2/metrics/preset-configs.yaml
+++ b/pgwatch2/metrics/preset-configs.yaml
@@ -42,6 +42,7 @@
   description: per DB stats
   metrics:
     pgbouncer_stats: 60
+    pgbouncer_pools: 60
 
 - name: pgpool
   description: pool global stats, 1 row per node ID

--- a/pgwatch2/pgwatch2.go
+++ b/pgwatch2/pgwatch2.go
@@ -241,6 +241,7 @@ const RECO_METRIC_NAME = "recommendations"
 const SPECIAL_METRIC_CHANGE_EVENTS = "change_events"
 const SPECIAL_METRIC_SERVER_LOG_EVENT_COUNTS = "server_log_event_counts"
 const SPECIAL_METRIC_PGBOUNCER_STATS = "pgbouncer_stats"
+const SPECIAL_METRIC_PGBOUNCER_POOLS = "pgbouncer_pools"
 const SPECIAL_METRIC_PGPOOL_STATS = "pgpool_stats"
 const SPECIAL_METRIC_INSTANCE_UP = "instance_up"
 const METRIC_CPU_LOAD = "cpu_load"
@@ -863,7 +864,7 @@ retry:
 			}
 
 			if epoch_ns == 0 {
-				if !ts_warning_printed && msg.MetricName != SPECIAL_METRIC_PGBOUNCER_STATS {
+				if !ts_warning_printed && msg.MetricName != SPECIAL_METRIC_PGBOUNCER_STATS && msg.MetricName != SPECIAL_METRIC_PGBOUNCER_POOLS {
 					log.Warning("No timestamp_ns found, (gatherer) server time will be used. measurement:", msg.MetricName)
 					ts_warning_printed = true
 				}
@@ -957,7 +958,7 @@ func SendToPostgres(storeMessages []MetricStoreMessage) error {
 			}
 
 			if epoch_ns == 0 {
-				if !ts_warning_printed && msg.MetricName != SPECIAL_METRIC_PGBOUNCER_STATS {
+				if !ts_warning_printed && msg.MetricName != SPECIAL_METRIC_PGBOUNCER_STATS && msg.MetricName != SPECIAL_METRIC_PGBOUNCER_POOLS {
 					log.Warning("No timestamp_ns found, server time will be used. measurement:", msg.MetricName)
 					ts_warning_printed = true
 				}

--- a/pgwatch2/sql/config_store/config_store.sql
+++ b/pgwatch2/sql/config_store/config_store.sql
@@ -127,7 +127,8 @@ insert into pgwatch2.preset_config (pc_name, pc_description, pc_config)
     }'),
     ('pgbouncer', 'per DB stats',
     '{
-    "pgbouncer_stats": 60
+    "pgbouncer_stats": 60,
+    "pgbouncer_pools": 60
     }'),
     ('pgpool', 'pool global stats, 1 row per node ID',
     '{

--- a/pgwatch2/sql/config_store/metric_definitions.sql
+++ b/pgwatch2/sql/config_store/metric_definitions.sql
@@ -5099,6 +5099,16 @@ values (
 false
 );
 
+/* pgbouncer_pools - assumes also that monitored DB has type 'pgbouncer' */
+insert into pgwatch2.metric(m_name, m_pg_version_from, m_sql, m_comment, m_is_helper)
+values (
+'pgbouncer_pools',
+0,
+'show pools',
+'pgbouncer per db statistics',
+false
+);
+
 /* pgpool_stats - assumes also that monitored DB has type 'pgpool' */
 insert into pgwatch2.metric(m_name, m_pg_version_from, m_sql, m_comment, m_is_helper)
 values (


### PR DESCRIPTION
hey @kmoppel 👋🏻 

here is the PR for "pools" in pgbouncer, probably not perfect but working 😁  but two open points:

- I don't use go, so probably the part on the pgwatch2.go could be done better
- exporting the grafana dashboard breaks your template, so I think posting here the query would be "safer"
`select
  $__timeGroup(time, $__interval),
  c as "cl_active"
from (
  select 
    (data->>'cl_active')::int8 as c,
    time
  from pgbouncer_pools
  where dbname = '$dbname' and $__timeFilter(time)
            and data->>'user' = 'CHANGEME'
) x`
basically I have 3 queries up: cl_active, sv_active and sv_idle . placed right to the cybertec banner.
![image](https://user-images.githubusercontent.com/506713/109340434-4d607b80-7869-11eb-964c-321e8ee2671c.png)

let me know what you think 😉 

cheers
Shin