### PR TITLE
helm - support mode without grafana

### DIFF
--- a/openshift_k8s/helm-chart-k8s-pg-storage/templates/deployment.yaml
+++ b/openshift_k8s/helm-chart-k8s-pg-storage/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
                   name: {{ template "pgwatch2.fullname" . }}-web
                   key: password
             {{- end }}
-            {{- if .Values.grafana.noAnonymous }}
+            {{- if and .Values.grafana.enabled .Values.grafana.noAnonymous }}
             - name: PW2_GRAFANANOANONYMOUS
               value: "{{ .Values.grafana.noAnonymous }}"
             - name: PW2_GRAFANAUSER
@@ -74,9 +74,11 @@ spec:
             - name: exporter
               containerPort: 9187
               protocol: TCP
+            {{- if .Values.grafana.enabled }}
             - name: grafana
               containerPort: 3000
               protocol: TCP
+            {{- end }}
             - name: database
               containerPort: 5432
               protocol: TCP

--- a/openshift_k8s/helm-chart-k8s-pg-storage/templates/grafana-ingress.yaml
+++ b/openshift_k8s/helm-chart-k8s-pg-storage/templates/grafana-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafana.ingress.enabled -}}
+{{- if and .Values.grafana.enabled .Values.grafana.ingress.enabled -}}
 {{- $fullName := include "pgwatch2.fullname" . -}}
 {{- $svcPort := .Values.grafana.service.servicePort -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}

--- a/openshift_k8s/helm-chart-k8s-pg-storage/templates/grafana-secrets.yaml
+++ b/openshift_k8s/helm-chart-k8s-pg-storage/templates/grafana-secrets.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafana.noAnonymous -}}
+{{- if and .Values.grafana.enabled .Values.grafana.noAnonymous -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/openshift_k8s/helm-chart-k8s-pg-storage/templates/grafana-service.yaml
+++ b/openshift_k8s/helm-chart-k8s-pg-storage/templates/grafana-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.grafana.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -37,3 +38,4 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "pgwatch2.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/openshift_k8s/helm-chart-k8s-pg-storage/values.yaml
+++ b/openshift_k8s/helm-chart-k8s-pg-storage/values.yaml
@@ -41,6 +41,7 @@ web:
     #      - pgwatch2-web.local
 
 grafana:
+  enabled: true
   service:
     type: ClusterIP
     servicePort: 3000


### PR DESCRIPTION
I needed a helm configuration without grafana, because I already has a grafana instance in my setup.