### PR TITLE
Typo fix

### DIFF
--- a/pgwatch2/sql/config_store/config_store.sql
+++ b/pgwatch2/sql/config_store/config_store.sql
@@ -286,7 +286,7 @@ insert into pgwatch2.preset_config (pc_name, pc_description, pc_config)
     "stat_statements_calls": 60,
     "table_io_stats": 300,
     "table_stats": 300,
-    "wal": 60,
+    "wal": 60
     }'),
    ('superuser_no_python', 'like exhaustive, but no PL/Python helpers',
     '{

--- a/pgwatch2/sql/config_store/metric_definitions.sql
+++ b/pgwatch2/sql/config_store/metric_definitions.sql
@@ -6811,7 +6811,7 @@ select
 $sql$
 );
 
-insert into pgwatch2.metric(m_name, m_pg_version_from, m_sql, m_sql_su)
+insert into pgwatch2.metric(m_name, m_pg_version_from, m_sql)
 values (
 'replication_slot_stats',
 14,
@@ -6833,7 +6833,7 @@ $sql$
 );
 
 
-insert into pgwatch2.metric(m_name, m_pg_version_from, m_sql, m_sql_su)
+insert into pgwatch2.metric(m_name, m_pg_version_from, m_sql)
 values (
 'wal_stats',
 14,


### PR DESCRIPTION
```
./build-docker-postgres.sh
docker run --rm -it -e PW2_TESTDB=true -P -p 8080:8080 -p 3000:3000 cybertec/pgwatch2-postgres
```
```
psql:/pgwatch2/sql/config_store/config_store.sql:411: ERROR:  invalid input syntax for type json
LINE 167:     '{
              ^
DETAIL:  Expected string, but found "}".
CONTEXT:  JSON data, line 15: ...300,
    "table_stats": 300,
    "wal": 60,
    }
INSERT 0 1
psql:/pgwatch2/sql/config_store/metric_definitions.sql:6833: ERROR:  INSERT has more target columns than expressions
LINE 1: ... pgwatch2.metric(m_name, m_pg_version_from, m_sql, m_sql_su)
                                                              ^
psql:/pgwatch2/sql/config_store/metric_definitions.sql:6854: ERROR:  INSERT has more target columns than expressions
LINE 1: ... pgwatch2.metric(m_name, m_pg_version_from, m_sql, m_sql_su)
                                                              ^
```