### PR TITLE
Remove grant for removed table

### DIFF
--- a/docker-launcher-postgres.sh
+++ b/docker-launcher-postgres.sh
@@ -84,7 +84,6 @@ su -c "psql -d pgwatch2 -f /pgwatch2/metrics/00_helpers/get_psutil_mem/9.1/metri
 su -c "psql -d pgwatch2 -f /pgwatch2/metrics/00_helpers/get_psutil_disk/9.1/metric.sql" postgres
 su -c "psql -d pgwatch2 -f /pgwatch2/metrics/00_helpers/get_psutil_disk_io_total/9.1/metric.sql" postgres
 su -c "psql -d pgwatch2 -c 'create extension pg_qualstats'" postgres
-su -c "psql -d pgwatch2 -c 'grant select on pg_qualstats_indexes_ddl to pgwatch2'" postgres
 
 if [ -n "$PW2_TESTDB" ] ; then
   su -c "psql -d pgwatch2 -f /pgwatch2/bootstrap/insert_test_monitored_db.sql" postgres


### PR DESCRIPTION
```
./build-docker-postgres.sh
docker run --rm -it -e PW2_TESTDB=true -P -p 8080:8080 -p 3000:3000 cybertec/pgwatch2-postgres
```
```
...
COMMENT
CREATE EXTENSION
ERROR:  relation "pg_qualstats_indexes_ddl" does not exist
INSERT 0 1
...
```

Current version of pg_qualstats extension (2.0.2) does not have pg_qualstats_indexes_ddl, it was removed at 2.0.0.