### PR TITLE
Create helpers if both of "--ping" and "--adhoc-create-helpers" provided

### DIFF
--- a/pgwatch2/pgwatch2.go
+++ b/pgwatch2/pgwatch2.go
@@ -5242,7 +5242,7 @@ func main() {
 					}
 				}
 
-				if !opts.Ping && (host.IsSuperuser || (adHocMode && StringToBoolOrFail(opts.AdHocCreateHelpers, "--adhoc-create-helpers"))) && IsPostgresDBType(db_type) && !ver.IsInRecovery {
+				if (!opts.Ping || (adHocMode && StringToBoolOrFail(opts.AdHocCreateHelpers, "--adhoc-create-helpers"))) && host.IsSuperuser && IsPostgresDBType(db_type) && !ver.IsInRecovery {
 					log.Infof("Trying to create helper functions if missing for \"%s\"...", db_unique)
 					_ = TryCreateMetricsFetchingHelpers(db_unique)
 				}


### PR DESCRIPTION
At the moment if we provide both arguments "--ping" and "--adhoc-create-helpers" it won't create helpers, I believe that the expected behavior would ping the database and create helpers. 