### PR TITLE
Bigger upstream merge batch

### DIFF
--- a/ENV_VARIABLES.md
+++ b/ENV_VARIABLES.md
@@ -66,6 +66,7 @@ NB! Some variables influence multiple components. Command line parameters overri
 - **PW2_DIRECT_OS_STATS** Extract OS related psutil statistics not via PL/Python wrappers but directly on host, i.e. assumes "push" setup. Default: off.
 - **PW2_MIN_DB_SIZE_MB** Smaller size DBs will be ignored and not monitored until they reach the threshold. Default: 0 (no size-based limiting).
 - **PW2_MAX_PARALLEL_CONNECTIONS_PER_DB** Max parallel metric fetches per DB. Note the multiplication effect on multi-DB instances. Default: 2
+- **PW2_EMERGENCY_PAUSE_TRIGGERFILE** When the file exists no metrics will be temporarily fetched / scraped. Default: /tmp/pgwatch2-emergency-pause
 
 
 ## Web UI

--- a/ENV_VARIABLES.md
+++ b/ENV_VARIABLES.md
@@ -67,6 +67,7 @@ NB! Some variables influence multiple components. Command line parameters overri
 - **PW2_MIN_DB_SIZE_MB** Smaller size DBs will be ignored and not monitored until they reach the threshold. Default: 0 (no size-based limiting).
 - **PW2_MAX_PARALLEL_CONNECTIONS_PER_DB** Max parallel metric fetches per DB. Note the multiplication effect on multi-DB instances. Default: 2
 - **PW2_EMERGENCY_PAUSE_TRIGGERFILE** When the file exists no metrics will be temporarily fetched / scraped. Default: /tmp/pgwatch2-emergency-pause
+- **PW2_NO_HELPER_FUNCTIONS** Ignore metric definitions using helper functions (in form get_smth()) and don't also roll out any helpers automatically. Default: false
 
 
 ## Web UI

--- a/ENV_VARIABLES.md
+++ b/ENV_VARIABLES.md
@@ -65,6 +65,7 @@ NB! Some variables influence multiple components. Command line parameters overri
 - **PW2_INSTANCE_LEVEL_CACHE_MAX_SECONDS** Max allowed staleness for instance level metric data shared between DBs of an instance. Affects 'continuous' host types only. Set to 0 to disable. Default: 30
 - **PW2_DIRECT_OS_STATS** Extract OS related psutil statistics not via PL/Python wrappers but directly on host, i.e. assumes "push" setup. Default: off.
 - **PW2_MIN_DB_SIZE_MB** Smaller size DBs will be ignored and not monitored until they reach the threshold. Default: 0 (no size-based limiting).
+- **PW2_MAX_PARALLEL_CONNECTIONS_PER_DB** Max parallel metric fetches per DB. Note the multiplication effect on multi-DB instances. Default: 2
 
 
 ## Web UI

--- a/ENV_VARIABLES.md
+++ b/ENV_VARIABLES.md
@@ -68,6 +68,7 @@ NB! Some variables influence multiple components. Command line parameters overri
 - **PW2_MAX_PARALLEL_CONNECTIONS_PER_DB** Max parallel metric fetches per DB. Note the multiplication effect on multi-DB instances. Default: 2
 - **PW2_EMERGENCY_PAUSE_TRIGGERFILE** When the file exists no metrics will be temporarily fetched / scraped. Default: /tmp/pgwatch2-emergency-pause
 - **PW2_NO_HELPER_FUNCTIONS** Ignore metric definitions using helper functions (in form get_smth()) and don't also roll out any helpers automatically. Default: false
+- **PW2_TRY_CREATE_LISTED_EXTS_IF_MISSING** Try creating the listed extensions (comma sep.) on first connect for all monitored DBs when missing. Main usage - pg_stat_statements. Default: ""
 
 
 ## Web UI

--- a/docker/Dockerfile-daemon
+++ b/docker/Dockerfile-daemon
@@ -1,4 +1,4 @@
-FROM golang:1.16.3
+FROM golang:1.17.2
 
 # For showing Git version via 'pgwatch2 --version'
 ARG GIT_HASH
@@ -10,7 +10,7 @@ ADD pgwatch2 /pgwatch2
 RUN cd /pgwatch2 && bash build_gatherer.sh
 
 
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 RUN apt-get -q update && apt-get -qy install wget git && apt autoremove -y && mkdir /pgwatch2
 

--- a/grafana_dashboards/prometheus/v7/postgres-version-overview/dashboard.json
+++ b/grafana_dashboards/prometheus/v7/postgres-version-overview/dashboard.json
@@ -1,0 +1,168 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+          },
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "id": null,
+    "links": [],
+    "panels": [
+      {
+        "datasource": null,
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "align": "auto",
+              "displayMode": "auto"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 21,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 2,
+        "options": {
+          "showHeader": true,
+          "sortBy": [
+            {
+              "desc": false,
+              "displayName": "Value"
+            }
+          ]
+        },
+        "pluginVersion": "8.1.6",
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "max(pgwatch2_settings_server_version_num{kubernetes_cluster=\"$kubernetes_cluster\"} <= $lte_server_version_num) by (dbname)",
+            "format": "table",
+            "instant": true,
+            "interval": "",
+            "legendFormat": "",
+            "refId": "A"
+          }
+        ],
+        "title": "\"server_version_num\"",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "Time": true
+              },
+              "indexByName": {},
+              "renameByName": {}
+            }
+          }
+        ],
+        "type": "table"
+      }
+    ],
+    "refresh": "",
+    "schemaVersion": 30,
+    "style": "dark",
+    "tags": [
+      "pgwatch2",
+      "postgres"
+    ],
+    "templating": {
+      "list": [
+        {
+          "allValue": null,
+          "datasource": null,
+          "definition": "label_values(pgwatch2_instance_up, kubernetes_cluster)",
+          "description": null,
+          "error": null,
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "kubernetes_cluster",
+          "options": [],
+          "query": {
+            "query": "label_values(pgwatch2_instance_up, kubernetes_cluster)",
+            "refId": "StandardVariableQuery"
+          },
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "type": "query"
+        },
+        {
+          "allValue": null,
+          "current": {
+            "selected": true,
+            "text": "120007",
+            "value": "120007"
+          },
+          "datasource": null,
+          "definition": "query_result(count_values(\"ver\", pgwatch2_settings_server_version_num))",
+          "description": null,
+          "error": null,
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "lte_server_version_num",
+          "options": [],
+          "query": {
+            "query": "query_result(count_values(\"ver\", pgwatch2_settings_server_version_num))",
+            "refId": "StandardVariableQuery"
+          },
+          "refresh": 1,
+          "regex": "/.*ver=\"([^\"*]+).*/",
+          "skipUrlSync": false,
+          "sort": 4,
+          "type": "query"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Postgres version overview",
+    "uid": null,
+    "version": 1
+  }

--- a/grafana_dashboards/prometheus/v7/postgres-version-overview/title.txt
+++ b/grafana_dashboards/prometheus/v7/postgres-version-overview/title.txt
@@ -1,0 +1,1 @@
+Postgres version overview

--- a/grafana_dashboards/prometheus/v7/wait-events/dashboard.json
+++ b/grafana_dashboards/prometheus/v7/wait-events/dashboard.json
@@ -1,0 +1,185 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+          },
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "id": null,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "datasource": null,
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "smooth",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 16,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 2,
+        "interval": "5m",
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi"
+          }
+        },
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "max(max_over_time(pgwatch2_wait_events_count{dbname='$dbname'}[10m])) by (wait_event)",
+            "interval": "",
+            "legendFormat": "{{wait_event}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Wait event counts",
+        "type": "timeseries"
+      },
+      {
+        "datasource": null,
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 16
+        },
+        "id": 4,
+        "options": {
+          "content": "<br>\nExplanations of individual wait_states are explained\n<a target=\"_blank\" href=\"https://www.postgresql.org/docs/13/monitoring-stats.html#WAIT-EVENT-ACTIVITY-TABLE\"> here</a>. NB! Mind the DB versions and switch accordingly!",
+          "mode": "html"
+        },
+        "pluginVersion": "8.2.3",
+        "type": "text"
+      }
+    ],
+    "refresh": "",
+    "schemaVersion": 31,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "allValue": null,
+          "datasource": null,
+          "definition": "label_values(dbname)",
+          "description": "",
+          "error": null,
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "dbname",
+          "options": [],
+          "query": {
+            "query": "label_values(dbname)",
+            "refId": "StandardVariableQuery"
+          },
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "type": "query"
+        },
+        {
+          "allValue": null,
+          "datasource": null,
+          "definition": "query_result(max(pgwatch2_settings_server_version_num{dbname=\"$dbname\"}))",
+          "description": null,
+          "error": null,
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "server_version_num",
+          "options": [],
+          "query": {
+            "query": "query_result(max(pgwatch2_settings_server_version_num{dbname=\"$dbname\"}))",
+            "refId": "StandardVariableQuery"
+          },
+          "refresh": 1,
+          "regex": "/(?<value>\\d+)/",
+          "skipUrlSync": false,
+          "sort": 0,
+          "type": "query"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-24h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Wait Events",
+    "uid": null,
+    "version": 1
+  }

--- a/grafana_dashboards/prometheus/v7/wait-events/title.txt
+++ b/grafana_dashboards/prometheus/v7/wait-events/title.txt
@@ -1,0 +1,1 @@
+Wait Events

--- a/pgwatch2/logparse.go
+++ b/pgwatch2/logparse.go
@@ -372,7 +372,7 @@ func tryDetermineLogFolder(mdb MonitoredDatabase) string {
 	sql := `select current_setting('data_directory') as dd, current_setting('log_directory') as ld`
 
 	log.Infof("[%s] Trying to determine server logs folder via SQL as host_config.logs_glob_path not specified...", mdb.DBUniqueName)
-	data, err, _ := DBExecReadByDbUniqueName(mdb.DBUniqueName, "", false, 0, sql)
+	data, err, _ := DBExecReadByDbUniqueName(mdb.DBUniqueName, "", 0, sql)
 	if err != nil {
 		log.Errorf("[%s] Failed to query data_directory and log_directory settings...are you superuser or have pg_monitor grant?", mdb.DBUniqueName)
 		return ""
@@ -390,7 +390,7 @@ func tryDetermineLogMessagesLanguage(mdb MonitoredDatabase) string {
 	sql := `select current_setting('lc_messages')::varchar(2) as lc_messages;`
 
 	log.Debugf("[%s] Trying to determine server log messages language...", mdb.DBUniqueName)
-	data, err, _ := DBExecReadByDbUniqueName(mdb.DBUniqueName, "", false, 0, sql)
+	data, err, _ := DBExecReadByDbUniqueName(mdb.DBUniqueName, "", 0, sql)
 	if err != nil {
 		log.Errorf("[%s] Failed to lc_messages settings: %s", mdb.DBUniqueName, err)
 		return ""

--- a/pgwatch2/metrics/00_helpers/get_table_bloat_approx_sql/12/metric.sql
+++ b/pgwatch2/metrics/00_helpers/get_table_bloat_approx_sql/12/metric.sql
@@ -12,7 +12,7 @@ LANGUAGE sql
 SECURITY DEFINER
 AS $$
 
-SELECT
+select /* pgwatch2_generated */
   quote_ident(schemaname)||'.'||quote_ident(tblname) as full_table_name,
   bloat_ratio as approx_bloat_percent,
   bloat_size as approx_bloat_bytes,

--- a/pgwatch2/metrics/00_helpers/get_table_bloat_approx_sql/9.0/metric.sql
+++ b/pgwatch2/metrics/00_helpers/get_table_bloat_approx_sql/9.0/metric.sql
@@ -13,7 +13,7 @@ LANGUAGE sql
 SECURITY DEFINER
 AS $$
 
-SELECT
+select /* pgwatch2_generated */
   quote_ident(schemaname)||'.'||quote_ident(tblname) as full_table_name,
   bloat_ratio as approx_bloat_percent,
   bloat_size as approx_bloat_bytes,

--- a/pgwatch2/metrics/archiver/9.4/metric.sql
+++ b/pgwatch2/metrics/archiver/9.4/metric.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   archived_count,
   failed_count,

--- a/pgwatch2/metrics/backends/10/metric.sql
+++ b/pgwatch2/metrics/backends/10/metric.sql
@@ -1,7 +1,7 @@
 with sa_snapshot as (
   select * from get_stat_activity()
 )
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   (select count(*) from sa_snapshot where backend_type = 'client backend') as total,
   (select count(*) from pg_stat_activity where pid != pg_backend_pid()) as instance_total,

--- a/pgwatch2/metrics/backends/10/metric_su.sql
+++ b/pgwatch2/metrics/backends/10/metric_su.sql
@@ -3,7 +3,7 @@ with sa_snapshot as (
   where pid != pg_backend_pid()
   and datname = current_database()
 )
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   (select count(*) from sa_snapshot where backend_type = 'client backend') as total,
   (select count(*) from pg_stat_activity where pid != pg_backend_pid()) as instance_total,

--- a/pgwatch2/metrics/backends/9.0/metric.sql
+++ b/pgwatch2/metrics/backends/9.0/metric.sql
@@ -1,7 +1,7 @@
 with sa_snapshot as (
   select * from get_stat_activity()
 )
-select
+select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     (select count(*) from sa_snapshot) as total,
     (select count(*) from pg_stat_activity where procpid != pg_backend_pid()) as instance_total,

--- a/pgwatch2/metrics/backends/9.0/metric_su.sql
+++ b/pgwatch2/metrics/backends/9.0/metric_su.sql
@@ -3,7 +3,7 @@ with sa_snapshot as (
   where datname = current_database()
   and procpid != pg_backend_pid()
 )
-select
+select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     (select count(*) from sa_snapshot) as total,
     (select count(*) from pg_stat_activity where procpid != pg_backend_pid()) as instance_total,

--- a/pgwatch2/metrics/backends/9.2/metric.sql
+++ b/pgwatch2/metrics/backends/9.2/metric.sql
@@ -1,7 +1,7 @@
 with sa_snapshot as (
   select * from get_stat_activity()
 )
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   (select count(*) from sa_snapshot) as total,
   (select count(*) from pg_stat_activity where pid != pg_backend_pid()) as instance_total,

--- a/pgwatch2/metrics/backends/9.2/metric_su.sql
+++ b/pgwatch2/metrics/backends/9.2/metric_su.sql
@@ -3,7 +3,7 @@ with sa_snapshot as (
   where datname = current_database()
   and pid != pg_backend_pid()
 )
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   (select count(*) from sa_snapshot) as total,
   (select count(*) from pg_stat_activity where pid != pg_backend_pid()) as instance_total,

--- a/pgwatch2/metrics/backends/9.4/metric.sql
+++ b/pgwatch2/metrics/backends/9.4/metric.sql
@@ -1,7 +1,7 @@
 with sa_snapshot as (
   select * from get_stat_activity()
 )
-select
+select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     (select count(*) from sa_snapshot) as total,
     (select count(*) from pg_stat_activity where pid != pg_backend_pid()) as instance_total,

--- a/pgwatch2/metrics/backends/9.4/metric_su.sql
+++ b/pgwatch2/metrics/backends/9.4/metric_su.sql
@@ -3,7 +3,7 @@ with sa_snapshot as (
   where datname = current_database()
   and pid != pg_backend_pid()
 )
-select
+select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     (select count(*) from sa_snapshot) as total,
     (select count(*) from pg_stat_activity where pid != pg_backend_pid()) as instance_total,

--- a/pgwatch2/metrics/backends/9.6/metric.sql
+++ b/pgwatch2/metrics/backends/9.6/metric.sql
@@ -1,7 +1,7 @@
 with sa_snapshot as (
   select * from get_stat_activity()
 )
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   (select count(*) from sa_snapshot) as total,
   (select count(*) from pg_stat_activity where pid != pg_backend_pid()) as instance_total,

--- a/pgwatch2/metrics/backends/9.6/metric_su.sql
+++ b/pgwatch2/metrics/backends/9.6/metric_su.sql
@@ -3,7 +3,7 @@ with sa_snapshot as (
   where datname = current_database()
   and pid != pg_backend_pid()
 )
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   (select count(*) from sa_snapshot) as total,
   (select count(*) from pg_stat_activity where pid != pg_backend_pid()) as instance_total,

--- a/pgwatch2/metrics/backup_age_pgbackrest/9.1/metric.sql
+++ b/pgwatch2/metrics/backup_age_pgbackrest/9.1/metric.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   retcode,
   backup_age_seconds,

--- a/pgwatch2/metrics/backup_age_walg/9.1/metric.sql
+++ b/pgwatch2/metrics/backup_age_walg/9.1/metric.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   retcode,
   backup_age_seconds,

--- a/pgwatch2/metrics/bgwriter/9.0/metric_master.sql
+++ b/pgwatch2/metrics/bgwriter/9.0/metric_master.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
    (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
    checkpoints_timed,
    checkpoints_req,

--- a/pgwatch2/metrics/bgwriter/9.2/metric_master.sql
+++ b/pgwatch2/metrics/bgwriter/9.2/metric_master.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
    (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
    checkpoints_timed,
    checkpoints_req,

--- a/pgwatch2/metrics/blocking_locks/9.2/metric.sql
+++ b/pgwatch2/metrics/blocking_locks/9.2/metric.sql
@@ -1,4 +1,4 @@
-SELECT
+select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 AS epoch_ns,
     waiting.locktype           AS tag_waiting_locktype,
     waiting_stm.usename::text  AS tag_waiting_user,

--- a/pgwatch2/metrics/blocking_locks/9.2/metric_su.sql
+++ b/pgwatch2/metrics/blocking_locks/9.2/metric_su.sql
@@ -4,7 +4,7 @@ WITH sa_snapshot AS (
   and not query like 'autovacuum:%'
   and pid != pg_backend_pid()
 )
-SELECT
+select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 AS epoch_ns,
     waiting.locktype           AS tag_waiting_locktype,
     waiting_stm.usename::text  AS tag_waiting_user,

--- a/pgwatch2/metrics/buffercache_by_db/9.2/metric.sql
+++ b/pgwatch2/metrics/buffercache_by_db/9.2/metric.sql
@@ -1,4 +1,4 @@
-SELECT
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   datname as tag_database,
   count(*) * (current_setting('block_size')::int8) as size_b

--- a/pgwatch2/metrics/buffercache_by_type/9.2/metric.sql
+++ b/pgwatch2/metrics/buffercache_by_type/9.2/metric.sql
@@ -1,4 +1,4 @@
-SELECT
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   CASE
     WHEN relkind = 'r' THEN 'Table'   -- TODO all relkinds covered?

--- a/pgwatch2/metrics/configuration_hashes/9.0/metric.sql
+++ b/pgwatch2/metrics/configuration_hashes/9.0/metric.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   name as tag_setting,
   coalesce(reset_val, '') as value

--- a/pgwatch2/metrics/cpu_load/9.0/metric.sql
+++ b/pgwatch2/metrics/cpu_load/9.0/metric.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   round(load_1min::numeric, 2)::float as load_1min,
   round(load_5min::numeric, 2)::float as load_5min,

--- a/pgwatch2/metrics/database_conflicts/9.2/metric_standby.sql
+++ b/pgwatch2/metrics/database_conflicts/9.2/metric_standby.sql
@@ -1,4 +1,4 @@
-SELECT
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   confl_tablespace,
   confl_lock,

--- a/pgwatch2/metrics/db_size/9.0/metric.sql
+++ b/pgwatch2/metrics/db_size/9.0/metric.sql
@@ -1,4 +1,7 @@
 select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   pg_database_size(current_database()) as size_b,
-  (select sum(pg_total_relation_size(oid))::int8 from pg_class where relkind = 'r' and relname LIKE E'pg\\_%') as catalog_size_b;
+  (select sum(pg_total_relation_size(c.oid))::int8
+   from pg_class c join pg_namespace n on n.oid = c.relnamespace
+   where nspname = 'pg_catalog' and relkind = 'r'
+  ) as catalog_size_b;

--- a/pgwatch2/metrics/db_size/9.0/metric.sql
+++ b/pgwatch2/metrics/db_size/9.0/metric.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   pg_database_size(current_database()) as size_b,
   (select sum(pg_total_relation_size(oid)) from pg_class where relkind = 'r' and relname LIKE E'pg\\_%') as catalog_size_b;

--- a/pgwatch2/metrics/db_size/9.0/metric.sql
+++ b/pgwatch2/metrics/db_size/9.0/metric.sql
@@ -1,3 +1,4 @@
 select
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
-  pg_database_size(current_database()) as size_b;
+  pg_database_size(current_database()) as size_b,
+  (select sum(pg_total_relation_size(oid)) from pg_class where relkind = 'r' and relname LIKE E'pg\\_%') as catalog_size_b;

--- a/pgwatch2/metrics/db_size/9.0/metric.sql
+++ b/pgwatch2/metrics/db_size/9.0/metric.sql
@@ -1,4 +1,4 @@
 select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   pg_database_size(current_database()) as size_b,
-  (select sum(pg_total_relation_size(oid)) from pg_class where relkind = 'r' and relname LIKE E'pg\\_%') as catalog_size_b;
+  (select sum(pg_total_relation_size(oid))::int8 from pg_class where relkind = 'r' and relname LIKE E'pg\\_%') as catalog_size_b;

--- a/pgwatch2/metrics/db_size/metric_attrs.yaml
+++ b/pgwatch2/metrics/db_size/metric_attrs.yaml
@@ -1,0 +1,2 @@
+---
+statement_timeout_seconds: 300

--- a/pgwatch2/metrics/db_size_approx/9.1/metric.sql
+++ b/pgwatch2/metrics/db_size_approx/9.1/metric.sql
@@ -1,0 +1,13 @@
+select /* pgwatch2_generated */
+  (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+  current_setting('block_size')::int8 * (
+    select sum(relpages) from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+    where c.relpersistence != 't'
+  ) as size_b,
+  current_setting('block_size')::int8 * (
+    select sum(relpages)
+    from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+    where nspname = 'pg_catalog'
+  ) as catalog_size_b;

--- a/pgwatch2/metrics/db_size_approx/9.1/metric.sql
+++ b/pgwatch2/metrics/db_size_approx/9.1/metric.sql
@@ -6,8 +6,13 @@ select /* pgwatch2_generated */
     where c.relpersistence != 't'
   ) as size_b,
   current_setting('block_size')::int8 * (
-    select sum(relpages)
+    select sum(c.relpages + coalesce(ct.relpages, 0) + coalesce(cti.relpages, 0))
     from pg_class c
     join pg_namespace n on n.oid = c.relnamespace
+    left join pg_class ct on ct.oid = c.reltoastrelid
+    left join pg_index ti on ti.indrelid = ct.oid
+    left join pg_class cti on cti.oid = ti.indexrelid
     where nspname = 'pg_catalog'
+    and (c.relkind = 'r'
+      or c.relkind = 'i' and not c.relname ~ '^pg_toast')
   ) as catalog_size_b;

--- a/pgwatch2/metrics/db_size_approx/column_attrs.yaml
+++ b/pgwatch2/metrics/db_size_approx/column_attrs.yaml
@@ -1,0 +1,2 @@
+---
+prometheus_all_gauge_columns: true

--- a/pgwatch2/metrics/db_size_approx/metric_attrs.yaml
+++ b/pgwatch2/metrics/db_size_approx/metric_attrs.yaml
@@ -1,0 +1,2 @@
+---
+metric_storage_name: db_size

--- a/pgwatch2/metrics/db_stats/10/metric.sql
+++ b/pgwatch2/metrics/db_stats/10/metric.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   numbackends,
   xact_commit,

--- a/pgwatch2/metrics/db_stats/10/metric_su.sql
+++ b/pgwatch2/metrics/db_stats/10/metric_su.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   numbackends,
   xact_commit,

--- a/pgwatch2/metrics/db_stats/12/metric.sql
+++ b/pgwatch2/metrics/db_stats/12/metric.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   numbackends,
   xact_commit,

--- a/pgwatch2/metrics/db_stats/12/metric_su.sql
+++ b/pgwatch2/metrics/db_stats/12/metric_su.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   numbackends,
   xact_commit,

--- a/pgwatch2/metrics/db_stats/14/metric.sql
+++ b/pgwatch2/metrics/db_stats/14/metric.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   numbackends,
   xact_commit,

--- a/pgwatch2/metrics/db_stats/14/metric.sql
+++ b/pgwatch2/metrics/db_stats/14/metric.sql
@@ -1,0 +1,35 @@
+select
+  (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+  numbackends,
+  xact_commit,
+  xact_rollback,
+  blks_read,
+  blks_hit,
+  tup_returned,
+  tup_fetched,
+  tup_inserted,
+  tup_updated,
+  tup_deleted,
+  conflicts,
+  temp_files,
+  temp_bytes,
+  deadlocks,
+  blk_read_time,
+  blk_write_time,
+  extract(epoch from (now() - pg_postmaster_start_time()))::int8 as postmaster_uptime_s,
+  extract(epoch from (now() - pg_backup_start_time()))::int8 as backup_duration_s,
+  checksum_failures,
+  extract(epoch from (now() - checksum_last_failure))::int8 as checksum_last_failure_s,
+  case when pg_is_in_recovery() then 1 else 0 end as in_recovery_int,
+  system_identifier::text as tag_sys_id,
+  session_time::int8,
+  active_time::int8,
+  idle_in_transaction_time::int8,
+  sessions,
+  sessions_abandoned,
+  sessions_fatal,
+  sessions_killed
+from
+  pg_stat_database, pg_control_system()
+where
+  datname = current_database();

--- a/pgwatch2/metrics/db_stats/14/metric_su.sql
+++ b/pgwatch2/metrics/db_stats/14/metric_su.sql
@@ -1,0 +1,35 @@
+select
+  (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+  numbackends,
+  xact_commit,
+  xact_rollback,
+  blks_read,
+  blks_hit,
+  tup_returned,
+  tup_fetched,
+  tup_inserted,
+  tup_updated,
+  tup_deleted,
+  conflicts,
+  temp_files,
+  temp_bytes,
+  deadlocks,
+  blk_read_time,
+  blk_write_time,
+  extract(epoch from (now() - coalesce((pg_stat_file('postmaster.pid', true)).modification, pg_postmaster_start_time())))::int8 as postmaster_uptime_s,
+  extract(epoch from (now() - pg_backup_start_time()))::int8 as backup_duration_s,
+  checksum_failures,
+  extract(epoch from (now() - checksum_last_failure))::int8 as checksum_last_failure_s,
+  case when pg_is_in_recovery() then 1 else 0 end as in_recovery_int,
+  system_identifier::text as tag_sys_id,
+  session_time::int8,
+  active_time::int8,
+  idle_in_transaction_time::int8,
+  sessions,
+  sessions_abandoned,
+  sessions_fatal,
+  sessions_killed
+from
+  pg_stat_database, pg_control_system()
+where
+  datname = current_database();

--- a/pgwatch2/metrics/db_stats/14/metric_su.sql
+++ b/pgwatch2/metrics/db_stats/14/metric_su.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   numbackends,
   xact_commit,

--- a/pgwatch2/metrics/db_stats/9.0/metric.sql
+++ b/pgwatch2/metrics/db_stats/9.0/metric.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   numbackends,
   xact_commit,

--- a/pgwatch2/metrics/db_stats/9.1/metric.sql
+++ b/pgwatch2/metrics/db_stats/9.1/metric.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   numbackends,
   xact_commit,

--- a/pgwatch2/metrics/db_stats/9.2/metric.sql
+++ b/pgwatch2/metrics/db_stats/9.2/metric.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   numbackends,
   xact_commit,

--- a/pgwatch2/metrics/db_stats/9.3/metric.sql
+++ b/pgwatch2/metrics/db_stats/9.3/metric.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   numbackends,
   xact_commit,

--- a/pgwatch2/metrics/db_stats_aurora/10/metric.sql
+++ b/pgwatch2/metrics/db_stats_aurora/10/metric.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   numbackends,
   xact_commit,

--- a/pgwatch2/metrics/db_stats_aurora/9.6/metric.sql
+++ b/pgwatch2/metrics/db_stats_aurora/9.6/metric.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   numbackends,
   xact_commit,

--- a/pgwatch2/metrics/index_hashes/9.0/metric.sql
+++ b/pgwatch2/metrics/index_hashes/9.0/metric.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   quote_ident(nspname)||'.'||quote_ident(c.relname) as tag_index,
   quote_ident(nspname)||'.'||quote_ident(r.relname) as "table",

--- a/pgwatch2/metrics/index_stats/10/metric.sql
+++ b/pgwatch2/metrics/index_stats/10/metric.sql
@@ -73,7 +73,7 @@ q_top_indexes AS (
              where not indisvalid
          ) zz
 )
-SELECT
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   schemaname::text as tag_schema,
   indexrelname::text as tag_index_name,

--- a/pgwatch2/metrics/index_stats/9.0/metric.sql
+++ b/pgwatch2/metrics/index_stats/9.0/metric.sql
@@ -72,7 +72,7 @@ q_top_indexes AS (
              where not indisvalid
          ) zz
 )
-SELECT
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   schemaname::text as tag_schema,
   indexrelname::text as tag_index_name,

--- a/pgwatch2/metrics/index_stats/9.1/metric.sql
+++ b/pgwatch2/metrics/index_stats/9.1/metric.sql
@@ -73,7 +73,7 @@ q_top_indexes AS (
              where not indisvalid
          ) zz
 )
-SELECT
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   schemaname::text as tag_schema,
   indexrelname::text as tag_index_name,

--- a/pgwatch2/metrics/instance_up/9.0/metric.sql
+++ b/pgwatch2/metrics/instance_up/9.0/metric.sql
@@ -1,7 +1,7 @@
 /* NB! This metric has some special handling attached to it - it will store a 0 value if the DB is not accessible.
    Thus it can be used to for example calculate some percentual "uptime" indicator.
 */
-select
+select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     1::int as is_up
 ;

--- a/pgwatch2/metrics/kpi/10/metric.sql
+++ b/pgwatch2/metrics/kpi/10/metric.sql
@@ -7,7 +7,7 @@ WITH q_stat_tables AS (
 q_stat_activity AS (
   SELECT * FROM get_stat_activity() WHERE pid != pg_backend_pid() AND datname = current_database()
 )
-SELECT
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   case
       when pg_is_in_recovery() = false then

--- a/pgwatch2/metrics/kpi/10/metric_su.sql
+++ b/pgwatch2/metrics/kpi/10/metric_su.sql
@@ -8,7 +8,7 @@ q_stat_activity AS (
     SELECT * FROM pg_stat_activity
     WHERE datname = current_database() AND pid != pg_backend_pid()
 )
-SELECT
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   case
       when pg_is_in_recovery() = false then

--- a/pgwatch2/metrics/kpi/9.0/metric.sql
+++ b/pgwatch2/metrics/kpi/9.0/metric.sql
@@ -7,7 +7,7 @@ WITH q_stat_tables AS (
 q_stat_activity AS (
   SELECT * FROM get_stat_activity()
 )
-SELECT
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   numbackends - 1 as numbackends,
   (select count(*) from q_stat_activity where not current_query in ('<IDLE>', '<IDLE> in transaction')) AS active_backends,

--- a/pgwatch2/metrics/kpi/9.0/metric_su.sql
+++ b/pgwatch2/metrics/kpi/9.0/metric_su.sql
@@ -7,7 +7,7 @@ WITH q_stat_tables AS (
 q_stat_activity AS (
   SELECT * FROM pg_stat_activity WHERE procpid != pg_backend_pid() AND datname = current_database()
 )
-SELECT
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   numbackends - 1 as numbackends,
   (select count(*) from q_stat_activity where not current_query in ('<IDLE>', '<IDLE> in transaction')) AS active_backends,

--- a/pgwatch2/metrics/kpi/9.2/metric.sql
+++ b/pgwatch2/metrics/kpi/9.2/metric.sql
@@ -7,7 +7,7 @@ WITH q_stat_tables AS (
 q_stat_activity AS (
  SELECT * FROM get_stat_activity()
 )
-SELECT
+select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     case
         when pg_is_in_recovery() = false then

--- a/pgwatch2/metrics/kpi/9.2/metric_su.sql
+++ b/pgwatch2/metrics/kpi/9.2/metric_su.sql
@@ -8,7 +8,7 @@ WITH q_stat_tables AS (
          SELECT * FROM pg_stat_activity
          WHERE datname = current_database() AND pid != pg_backend_pid()
      )
-SELECT
+select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     case
         when pg_is_in_recovery() = false then

--- a/pgwatch2/metrics/kpi/9.6/metric.sql
+++ b/pgwatch2/metrics/kpi/9.6/metric.sql
@@ -7,7 +7,7 @@ WITH q_stat_tables AS (
 q_stat_activity AS (
   SELECT * FROM get_stat_activity() WHERE pid != pg_backend_pid() AND datname = current_database()
 )
-SELECT
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   case
       when pg_is_in_recovery() = false then

--- a/pgwatch2/metrics/kpi/9.6/metric_su.sql
+++ b/pgwatch2/metrics/kpi/9.6/metric_su.sql
@@ -8,7 +8,7 @@ q_stat_activity AS (
     SELECT * FROM pg_stat_activity
     WHERE datname = current_database() AND pid != pg_backend_pid()
 )
-SELECT
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   case
       when pg_is_in_recovery() = false then

--- a/pgwatch2/metrics/locks/9.0/metric.sql
+++ b/pgwatch2/metrics/locks/9.0/metric.sql
@@ -7,7 +7,7 @@ WITH q_locks AS (
     pid != pg_backend_pid()
     and database = (select oid from pg_database where datname = current_database())
 )
-SELECT
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   locktypes AS tag_locktype,
   coalesce((select count(*) FROM q_locks WHERE locktype = locktypes), 0) AS count

--- a/pgwatch2/metrics/locks_mode/9.0/metric.sql
+++ b/pgwatch2/metrics/locks_mode/9.0/metric.sql
@@ -7,7 +7,7 @@ WITH q_locks AS (
     pid != pg_backend_pid()
     and database = (select oid from pg_database where datname = current_database())
 )
-SELECT
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   lockmodes AS tag_lockmode,
   coalesce((select count(*) FROM q_locks WHERE mode = lockmodes), 0) AS count

--- a/pgwatch2/metrics/logical_subscriptions/10/metric.sql
+++ b/pgwatch2/metrics/logical_subscriptions/10/metric.sql
@@ -1,7 +1,7 @@
 with q_sr as (
   select * from pg_subscription_rel
 )
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   subname::text as tag_subname,
   subenabled,

--- a/pgwatch2/metrics/preset-configs.yaml
+++ b/pgwatch2/metrics/preset-configs.yaml
@@ -191,6 +191,7 @@
     table_io_stats: 300
     table_stats: 300
     wal: 60
+    wait_events: 60
 
 - name: superuser_no_python
   description: like exhaustive, but no PL/Python helpers

--- a/pgwatch2/metrics/preset-configs.yaml
+++ b/pgwatch2/metrics/preset-configs.yaml
@@ -92,7 +92,7 @@
     wal: 60
     wal_size: 120
     kpi: 120
-#    stat_ssl: 120
+    stat_ssl: 120
     psutil_cpu: 120
     psutil_mem: 120
     psutil_disk: 120

--- a/pgwatch2/metrics/preset-configs.yaml
+++ b/pgwatch2/metrics/preset-configs.yaml
@@ -178,22 +178,19 @@
 - name: prometheus-async
   description: tuned for the new async (background collection) Prom feature. NB! Prom tolerates max. 10min time lag, so intervals should be smaller than 600
   metrics:
-    archiver: 60
     backends: 30
     bgwriter: 60
     db_stats: 30
     db_size: 300
-    locks: 30
     locks_mode: 30
     replication: 120
     replication_slots: 120
     settings: 300
-    sequence_health: 300
     sproc_stats: 180
-    stat_statements_calls: 30
+    stat_statements_calls: 60
     table_io_stats: 300
     table_stats: 300
-    wal: 30
+    wal: 60
 
 - name: superuser_no_python
   description: like exhaustive, but no PL/Python helpers

--- a/pgwatch2/metrics/preset-configs.yaml
+++ b/pgwatch2/metrics/preset-configs.yaml
@@ -92,7 +92,7 @@
     wal: 60
     wal_size: 120
     kpi: 120
-    stat_ssl: 120
+#    stat_ssl: 120
     psutil_cpu: 120
     psutil_mem: 120
     psutil_disk: 120

--- a/pgwatch2/metrics/privilege_changes/9.0/metric.sql
+++ b/pgwatch2/metrics/privilege_changes/9.0/metric.sql
@@ -1,4 +1,4 @@
-SELECT
+select /* pgwatch2_generated */
     (extract(epoch FROM now()) * 1e9)::int8 AS epoch_ns,
     *
 FROM (

--- a/pgwatch2/metrics/psutil_cpu/9.0/metric.sql
+++ b/pgwatch2/metrics/psutil_cpu/9.0/metric.sql
@@ -1,4 +1,4 @@
-SELECT
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   round(cpu_utilization::numeric, 2)::float as cpu_utilization,
   round(load_1m_norm::numeric, 2)::float as load_1m_norm,

--- a/pgwatch2/metrics/psutil_disk/9.0/metric.sql
+++ b/pgwatch2/metrics/psutil_disk/9.0/metric.sql
@@ -1,4 +1,4 @@
-SELECT
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   dir_or_tablespace as tag_dir_or_tablespace,
   path as tag_path,

--- a/pgwatch2/metrics/psutil_disk_io_total/9.0/metric.sql
+++ b/pgwatch2/metrics/psutil_disk_io_total/9.0/metric.sql
@@ -1,4 +1,4 @@
-SELECT
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   read_count,
   write_count,

--- a/pgwatch2/metrics/psutil_mem/9.0/metric.sql
+++ b/pgwatch2/metrics/psutil_mem/9.0/metric.sql
@@ -1,4 +1,4 @@
-SELECT
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   total, used, free, buff_cache, available, percent,
   swap_total, swap_used, swap_free, swap_percent

--- a/pgwatch2/metrics/reco_add_index/9.1/metric_master.sql
+++ b/pgwatch2/metrics/reco_add_index/9.1/metric_master.sql
@@ -1,5 +1,5 @@
 /* assumes the pg_qualstats extension and superuser or select grants on pg_qualstats_indexes_ddl view */
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   'create_index'::text as tag_reco_topic,
   quote_ident(nspname::text)||'.'||quote_ident(relid::text) as tag_object_name,

--- a/pgwatch2/metrics/reco_add_index_ext_qualstats_2.0/9.1/metric_master.sql
+++ b/pgwatch2/metrics/reco_add_index_ext_qualstats_2.0/9.1/metric_master.sql
@@ -1,5 +1,5 @@
 /* assumes the pg_qualstats extension and superuser or select grant on pg_qualstats_index_advisor() function */
-SELECT
+select /* pgwatch2_generated */
   epoch_ns,
   tag_reco_topic,
   tag_object_name,

--- a/pgwatch2/metrics/reco_default_public_schema/9.0/metric_master.sql
+++ b/pgwatch2/metrics/reco_default_public_schema/9.0/metric_master.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   'default_public_schema_privs'::text as tag_reco_topic,
   nspname::text as tag_object_name,

--- a/pgwatch2/metrics/reco_disabled_triggers/9.0/metric_master.sql
+++ b/pgwatch2/metrics/reco_disabled_triggers/9.0/metric_master.sql
@@ -1,5 +1,5 @@
 /* "temporarily" disabled triggers might be forgotten about... */
-select
+select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     'disabled_triggers'::text as tag_reco_topic,
     quote_ident(nspname)||'.'||quote_ident(relname) as tag_object_name,

--- a/pgwatch2/metrics/reco_drop_index/9.0/metric_master.sql
+++ b/pgwatch2/metrics/reco_drop_index/9.0/metric_master.sql
@@ -1,5 +1,5 @@
 /* assumes the pg_qualstats extension */
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   'drop_index'::text as tag_reco_topic,
   quote_ident(schemaname)||'.'||quote_ident(indexrelname) as tag_object_name,

--- a/pgwatch2/metrics/reco_drop_index/9.4/metric_master.sql
+++ b/pgwatch2/metrics/reco_drop_index/9.4/metric_master.sql
@@ -1,5 +1,5 @@
 /* assumes the pg_qualstats extension */
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   'drop_index'::text as tag_reco_topic,
   quote_ident(schemaname)||'.'||quote_ident(indexrelname) as tag_object_name,

--- a/pgwatch2/metrics/reco_nested_views/9.1/metric_master.sql
+++ b/pgwatch2/metrics/reco_nested_views/9.1/metric_master.sql
@@ -37,7 +37,7 @@ UNION ALL
      AND d.deptype = 'n'
      AND v.oid <> views.view  -- avoid loop
 )
-SELECT
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   'overly_nested_views'::text AS tag_reco_topic,
   full_name::text as tag_object_name,

--- a/pgwatch2/metrics/reco_partial_index_candidates/9.0/metric.sql
+++ b/pgwatch2/metrics/reco_partial_index_candidates/9.0/metric.sql
@@ -1,4 +1,4 @@
-select distinct
+select distinct /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     'partial_index_candidates'::text as tag_reco_topic,
     quote_ident(ni.nspname)||'.'||quote_ident(ci.relname) as tag_object_name,

--- a/pgwatch2/metrics/reco_sprocs_wo_search_path/9.1/metric_master.sql
+++ b/pgwatch2/metrics/reco_sprocs_wo_search_path/9.1/metric_master.sql
@@ -1,5 +1,5 @@
 with q_sprocs as (
-select
+select /* pgwatch2_generated */
   format('%s.%s', quote_ident(nspname), quote_ident(proname)) as sproc_name,
   'alter function ' || proname || '(' || pg_get_function_arguments(p.oid) || ') set search_path = X;' as fix_sql
 from
@@ -8,7 +8,7 @@ from
   where prosecdef and not 'search_path' = ANY(coalesce(proconfig, '{}'::text[]))
   and not pg_catalog.obj_description(p.oid, 'pg_proc') ~ 'pgwatch2'
 )
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   'sprocs_wo_search_path'::text as tag_reco_topic,
   sproc_name::text as tag_object_name,

--- a/pgwatch2/metrics/reco_superusers/9.1/metric_master.sql
+++ b/pgwatch2/metrics/reco_superusers/9.1/metric_master.sql
@@ -7,7 +7,7 @@ with q_su as (
 q_total as (
   select count(*) from pg_roles where rolcanlogin
 )
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   'superuser_count'::text as tag_reco_topic,
   '-'::text as tag_object_name,

--- a/pgwatch2/metrics/replication/10/metric.sql
+++ b/pgwatch2/metrics/replication/10/metric.sql
@@ -1,4 +1,4 @@
-SELECT
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   application_name as tag_application_name,
   concat(coalesce(client_addr::text, client_hostname), '_', client_port::text) as tag_client_info,

--- a/pgwatch2/metrics/replication/9.2/metric.sql
+++ b/pgwatch2/metrics/replication/9.2/metric.sql
@@ -1,4 +1,4 @@
-SELECT
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   application_name as tag_application_name,
   concat(coalesce(client_addr::text, client_hostname), '_', client_port::text) as tag_client_info,

--- a/pgwatch2/metrics/replication/9.2/metric_su.sql
+++ b/pgwatch2/metrics/replication/9.2/metric_su.sql
@@ -1,4 +1,4 @@
-SELECT
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   application_name as tag_application_name,
   concat(coalesce(client_addr::text, client_hostname), '_', client_port::text) as tag_client_info,

--- a/pgwatch2/metrics/replication_slot_stats/14/metric.sql
+++ b/pgwatch2/metrics/replication_slot_stats/14/metric.sql
@@ -1,0 +1,13 @@
+select
+  (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+  slot_name::text as tag_slot_name,
+  spill_txns,
+  spill_count,
+  spill_bytes,
+  stream_txns,
+  stream_count,
+  stream_bytes,
+  total_txns,
+  total_bytes
+from
+  pg_stat_replication_slots;

--- a/pgwatch2/metrics/replication_slot_stats/14/metric.sql
+++ b/pgwatch2/metrics/replication_slot_stats/14/metric.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   slot_name::text as tag_slot_name,
   spill_txns,

--- a/pgwatch2/metrics/replication_slots/10/metric_master.sql
+++ b/pgwatch2/metrics/replication_slots/10/metric_master.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   slot_name::text as tag_slot_name,
   coalesce(plugin, 'physical')::text as tag_plugin,

--- a/pgwatch2/metrics/replication_slots/9.4/metric_master.sql
+++ b/pgwatch2/metrics/replication_slots/9.4/metric_master.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   slot_name::text as tag_slot_name,
   coalesce(plugin, 'physical')::text as tag_plugin,

--- a/pgwatch2/metrics/sequence_health/10/metric.sql
+++ b/pgwatch2/metrics/sequence_health/10/metric.sql
@@ -1,7 +1,7 @@
 with q_seq_data as (
     select * from get_sequences()
 )
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   (select round(100.0 * coalesce(max(last_value::numeric / max_value), 0), 2)::float from q_seq_data where not cycle) as max_used_pct,
   (select count(*) from q_seq_data where not cycle and last_value::numeric / max_value > 0.5) as p50_used_seq_count,

--- a/pgwatch2/metrics/sequence_health/10/metric_su.sql
+++ b/pgwatch2/metrics/sequence_health/10/metric_su.sql
@@ -1,7 +1,7 @@
 with q_seq_data as (
     select * from pg_sequences
 )
-select
+select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     (select round(100.0 * coalesce(max(last_value::numeric / max_value), 0), 2)::float from q_seq_data where not cycle) as max_used_pct,
     (select count(*) from q_seq_data where not cycle and last_value::numeric / max_value > 0.5) as p50_used_seq_count,

--- a/pgwatch2/metrics/settings/10/metric.sql
+++ b/pgwatch2/metrics/settings/10/metric.sql
@@ -5,7 +5,7 @@ select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   current_setting('server_version') as server_version,
   current_setting('server_version_num')::int8 as server_version_num,
-  (regexp_matches(regexp_replace(current_setting('server_version'), '(beta|devel).*', '', 'g'), E'\\d+\\.?\\d+?'))[1]::float8 as major_version,
+  (regexp_matches(regexp_replace(current_setting('server_version'), '(beta|devel).*', '', 'g'), E'\\d+'))[1]::float8 as major_version,
   current_setting('block_size')::int as block_size,
   current_setting('max_connections')::int as max_connections,
   current_setting('hot_standby') as hot_standby,

--- a/pgwatch2/metrics/settings/9.0/metric.sql
+++ b/pgwatch2/metrics/settings/9.0/metric.sql
@@ -1,7 +1,7 @@
 with qs as (
   select name, setting from pg_settings
 )
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   current_setting('server_version') as server_version,
   current_setting('server_version_num')::int8 as server_version_num,

--- a/pgwatch2/metrics/show_plans_realtime/10/metric.sql
+++ b/pgwatch2/metrics/show_plans_realtime/10/metric.sql
@@ -1,5 +1,5 @@
 /* assumes pg_show_plans extension */
-select
+select /* pgwatch2_generated */
   max((extract(epoch from now()) * 1e9)::int8) as epoch_ns,
   max(extract(epoch from now() - query_start))::int as max_s,
   avg(extract(epoch from now() - query_start))::int as avg_s,

--- a/pgwatch2/metrics/show_plans_realtime/9.0/metric.sql
+++ b/pgwatch2/metrics/show_plans_realtime/9.0/metric.sql
@@ -1,5 +1,5 @@
 /* assumes pg_show_plans extension */
-select
+select /* pgwatch2_generated */
   max((extract(epoch from now()) * 1e9)::int8) as epoch_ns,
   max(extract(epoch from now() - query_start))::int as max_s,
   avg(extract(epoch from now() - query_start))::int as avg_s,

--- a/pgwatch2/metrics/smart_health_per_disk/9.1/metric.sql
+++ b/pgwatch2/metrics/smart_health_per_disk/9.1/metric.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   device as tag_device,
   retcode

--- a/pgwatch2/metrics/sproc_hashes/9.0/metric.sql
+++ b/pgwatch2/metrics/sproc_hashes/9.0/metric.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   p.oid::text as tag_oid,
   quote_ident(nspname)||'.'||quote_ident(proname) as tag_sproc,

--- a/pgwatch2/metrics/sproc_stats/9.0/metric.sql
+++ b/pgwatch2/metrics/sproc_stats/9.0/metric.sql
@@ -1,4 +1,4 @@
-SELECT
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   schemaname::text AS tag_schema,
   funcname::text  AS tag_function_name,

--- a/pgwatch2/metrics/stat_activity_realtime/10/metric.sql
+++ b/pgwatch2/metrics/stat_activity_realtime/10/metric.sql
@@ -1,4 +1,4 @@
-SELECT
+select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     pid as tag_pid,
     usename::text AS user,

--- a/pgwatch2/metrics/stat_activity_realtime/9.0/metric.sql
+++ b/pgwatch2/metrics/stat_activity_realtime/9.0/metric.sql
@@ -1,4 +1,4 @@
-SELECT
+select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     pid as tag_pid,
     usename::text AS user,

--- a/pgwatch2/metrics/stat_activity_realtime/9.2/metric.sql
+++ b/pgwatch2/metrics/stat_activity_realtime/9.2/metric.sql
@@ -1,4 +1,4 @@
-SELECT
+select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     pid as tag_pid,
     usename::text AS user,

--- a/pgwatch2/metrics/stat_activity_realtime/9.6/metric.sql
+++ b/pgwatch2/metrics/stat_activity_realtime/9.6/metric.sql
@@ -1,4 +1,4 @@
-SELECT
+select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     pid as tag_pid,
     usename::text AS user,

--- a/pgwatch2/metrics/stat_ssl/9.5/metric.sql
+++ b/pgwatch2/metrics/stat_ssl/9.5/metric.sql
@@ -1,4 +1,4 @@
-SELECT
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   ssl,
   count(*)

--- a/pgwatch2/metrics/stat_ssl/9.5/metric.sql
+++ b/pgwatch2/metrics/stat_ssl/9.5/metric.sql
@@ -1,12 +1,14 @@
 select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
-  ssl,
-  count(*)
+  count(*) as total,
+  count(*) FILTER (WHERE ssl) as "on",
+  count(*) FILTER (WHERE NOT ssl) as "off"
 FROM
   pg_stat_ssl AS s,
   get_stat_activity() AS a
 WHERE
   a.pid = s.pid
   AND a.datname = current_database()
-GROUP BY
-  1, 2;
+  AND a.pid <> pg_backend_pid()
+  AND NOT (a.client_addr = '127.0.0.1' OR client_port = -1)
+;

--- a/pgwatch2/metrics/stat_ssl/9.5/metric_su.sql
+++ b/pgwatch2/metrics/stat_ssl/9.5/metric_su.sql
@@ -1,4 +1,4 @@
-SELECT
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   ssl,
   count(*)

--- a/pgwatch2/metrics/stat_ssl/9.5/metric_su.sql
+++ b/pgwatch2/metrics/stat_ssl/9.5/metric_su.sql
@@ -1,12 +1,14 @@
 select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
-  ssl,
-  count(*)
+  count(*) as total,
+  count(*) FILTER (WHERE ssl) as "on",
+  count(*) FILTER (WHERE NOT ssl) as "off"
 FROM
   pg_stat_ssl AS s,
   pg_stat_activity AS a
 WHERE
   a.pid = s.pid
   AND a.datname = current_database()
-GROUP BY
-  1, 2;
+  AND a.pid <> pg_backend_pid()
+  AND NOT (a.client_addr = '127.0.0.1' OR client_port = -1)
+;

--- a/pgwatch2/metrics/stat_statements/13/metric.sql
+++ b/pgwatch2/metrics/stat_statements/13/metric.sql
@@ -45,7 +45,7 @@ WITH q_data AS (
         GROUP BY
             queryid
 )
-SELECT
+select /* pgwatch2_generated */
     (EXTRACT(epoch FROM now()) * 1e9)::int8 AS epoch_ns,
     b.tag_queryid,
     b.users,
@@ -77,7 +77,7 @@ FROM (
             total_time DESC
         LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT
@@ -88,7 +88,7 @@ FROM (
         calls DESC
     LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT
@@ -101,7 +101,7 @@ FROM (
         shared_blks_read DESC
     LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT
@@ -114,7 +114,7 @@ FROM (
         shared_blks_written DESC
     LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT
@@ -127,7 +127,7 @@ FROM (
         temp_blks_read DESC
     LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT

--- a/pgwatch2/metrics/stat_statements/13/metric_su.sql
+++ b/pgwatch2/metrics/stat_statements/13/metric_su.sql
@@ -45,7 +45,7 @@ WITH q_data AS (
         GROUP BY
             queryid
 )
-SELECT
+select /* pgwatch2_generated */
     (EXTRACT(epoch FROM now()) * 1e9)::int8 AS epoch_ns,
     b.tag_queryid,
     b.users,
@@ -77,7 +77,7 @@ FROM (
             total_time DESC
         LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT
@@ -88,7 +88,7 @@ FROM (
         calls DESC
     LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT
@@ -101,7 +101,7 @@ FROM (
         shared_blks_read DESC
     LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT
@@ -114,7 +114,7 @@ FROM (
         shared_blks_written DESC
     LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT
@@ -127,7 +127,7 @@ FROM (
         temp_blks_read DESC
     LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT

--- a/pgwatch2/metrics/stat_statements/9.2/metric.sql
+++ b/pgwatch2/metrics/stat_statements/9.2/metric.sql
@@ -70,7 +70,7 @@ FROM (
             total_time DESC
         LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT
@@ -81,7 +81,7 @@ FROM (
         calls DESC
     LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT
@@ -94,7 +94,7 @@ FROM (
         shared_blks_read DESC
     LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT
@@ -107,7 +107,7 @@ FROM (
         shared_blks_written DESC
     LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT
@@ -120,7 +120,7 @@ FROM (
         temp_blks_read DESC
     LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT

--- a/pgwatch2/metrics/stat_statements/9.2/metric_su.sql
+++ b/pgwatch2/metrics/stat_statements/9.2/metric_su.sql
@@ -70,7 +70,7 @@ FROM (
             total_time DESC
         LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT
@@ -81,7 +81,7 @@ FROM (
         calls DESC
     LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT
@@ -94,7 +94,7 @@ FROM (
         shared_blks_read DESC
     LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT
@@ -107,7 +107,7 @@ FROM (
         shared_blks_written DESC
     LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT
@@ -120,7 +120,7 @@ FROM (
         temp_blks_read DESC
     LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT

--- a/pgwatch2/metrics/stat_statements/9.4/metric.sql
+++ b/pgwatch2/metrics/stat_statements/9.4/metric.sql
@@ -70,7 +70,7 @@ FROM (
             total_time DESC
         LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT
@@ -81,7 +81,7 @@ FROM (
         calls DESC
     LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT
@@ -94,7 +94,7 @@ FROM (
         shared_blks_read DESC
     LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT
@@ -107,7 +107,7 @@ FROM (
         shared_blks_written DESC
     LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT
@@ -120,7 +120,7 @@ FROM (
         temp_blks_read DESC
     LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT

--- a/pgwatch2/metrics/stat_statements/9.4/metric_su.sql
+++ b/pgwatch2/metrics/stat_statements/9.4/metric_su.sql
@@ -70,7 +70,7 @@ FROM (
             total_time DESC
         LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT
@@ -81,7 +81,7 @@ FROM (
         calls DESC
     LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT
@@ -94,7 +94,7 @@ FROM (
         shared_blks_read DESC
     LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT
@@ -107,7 +107,7 @@ FROM (
         shared_blks_written DESC
     LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT
@@ -120,7 +120,7 @@ FROM (
         temp_blks_read DESC
     LIMIT 100) a
 UNION
-SELECT
+select /* pgwatch2_generated */
     *
 FROM (
     SELECT

--- a/pgwatch2/metrics/stat_statements_calls/13/metric.sql
+++ b/pgwatch2/metrics/stat_statements_calls/13/metric.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   coalesce(sum(calls), 0)::int8 as calls,
   coalesce(round(sum(total_exec_time)::numeric, 3), 0)::float8 as total_time,

--- a/pgwatch2/metrics/stat_statements_calls/9.2/metric.sql
+++ b/pgwatch2/metrics/stat_statements_calls/9.2/metric.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   coalesce(sum(calls), 0)::int8 as calls,
   coalesce(round(sum(total_time)::numeric, 3), 0)::float8 as total_time

--- a/pgwatch2/metrics/stat_statements_no_query_text/13/metric.sql
+++ b/pgwatch2/metrics/stat_statements_no_query_text/13/metric.sql
@@ -1,5 +1,5 @@
 with q_data as (
-  select
+  select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     '-' as tag_query,
     queryid::text as tag_queryid,

--- a/pgwatch2/metrics/stat_statements_no_query_text/13/metric_su.sql
+++ b/pgwatch2/metrics/stat_statements_no_query_text/13/metric_su.sql
@@ -1,5 +1,5 @@
 with q_data as (
-  select
+  select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     '-' as tag_query,
     queryid::text as tag_queryid,

--- a/pgwatch2/metrics/stat_statements_no_query_text/9.2/metric.sql
+++ b/pgwatch2/metrics/stat_statements_no_query_text/9.2/metric.sql
@@ -1,5 +1,5 @@
 with q_data as (
-    select
+    select /* pgwatch2_generated */
         (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
         (regexp_replace(md5(query), E'\\D', '', 'g'))::varchar(10)::int8 as tag_queryid,
         '-' as tag_query,

--- a/pgwatch2/metrics/stat_statements_no_query_text/9.2/metric_su.sql
+++ b/pgwatch2/metrics/stat_statements_no_query_text/9.2/metric_su.sql
@@ -1,5 +1,5 @@
 with q_data as (
-    select
+    select /* pgwatch2_generated */
         (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
         (regexp_replace(md5(query), E'\\D', '', 'g'))::varchar(10)::int8 as tag_queryid,
         '-' as tag_query,

--- a/pgwatch2/metrics/stat_statements_no_query_text/9.4/metric.sql
+++ b/pgwatch2/metrics/stat_statements_no_query_text/9.4/metric.sql
@@ -1,5 +1,5 @@
 with q_data as (
-  select
+  select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     '-' as tag_query,
     queryid::text as tag_queryid,

--- a/pgwatch2/metrics/stat_statements_no_query_text/9.4/metric_su.sql
+++ b/pgwatch2/metrics/stat_statements_no_query_text/9.4/metric_su.sql
@@ -1,5 +1,5 @@
 with q_data as (
-  select
+  select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     '-' as tag_query,
     queryid::text as tag_queryid,

--- a/pgwatch2/metrics/table_bloat_approx_stattuple/9.5/metric_master.sql
+++ b/pgwatch2/metrics/table_bloat_approx_stattuple/9.5/metric_master.sql
@@ -1,5 +1,5 @@
 /* NB! accessing pgstattuple_approx directly requires superuser or pg_stat_scan_tables/pg_monitor builtin roles */
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   quote_ident(n.nspname)||'.'||quote_ident(c.relname) as tag_full_table_name,
   approx_free_percent,

--- a/pgwatch2/metrics/table_bloat_approx_summary/10/metric.sql
+++ b/pgwatch2/metrics/table_bloat_approx_summary/10/metric.sql
@@ -17,7 +17,7 @@ with table_bloat_approx as (
         and c.relpages >= 128 -- tables >1mb
         and not n.nspname != 'information_schema'
 )
-select
+select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     approx_free_percent,
     approx_free_space as approx_free_space_b,

--- a/pgwatch2/metrics/table_bloat_approx_summary/9.5/metric_master.sql
+++ b/pgwatch2/metrics/table_bloat_approx_summary/9.5/metric_master.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   approx_free_percent,
   approx_free_space as approx_free_space_b,

--- a/pgwatch2/metrics/table_bloat_approx_summary/9.5/metric_su.sql
+++ b/pgwatch2/metrics/table_bloat_approx_summary/9.5/metric_su.sql
@@ -14,7 +14,7 @@ with table_bloat_approx as (
         and c.relpages >= 128 -- tables >1mb
         and not n.nspname like any (array[E'pg\\_%', 'information_schema'])
 )
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   approx_free_percent,
   approx_free_space as approx_free_space_b,

--- a/pgwatch2/metrics/table_bloat_approx_summary_sql/12/metric.sql
+++ b/pgwatch2/metrics/table_bloat_approx_summary_sql/12/metric.sql
@@ -1,7 +1,7 @@
 WITH q_bloat AS (
     select * from get_table_bloat_approx_sql()
 )
-SELECT
+select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     (select sum(approx_bloat_bytes) from q_bloat) as approx_table_bloat_b,
     ((select sum(approx_bloat_bytes) from q_bloat) * 100 / pg_database_size(current_database()))::int8 as approx_bloat_percentage

--- a/pgwatch2/metrics/table_bloat_approx_summary_sql/12/metric_su.sql
+++ b/pgwatch2/metrics/table_bloat_approx_summary_sql/12/metric_su.sql
@@ -111,7 +111,7 @@ WITH q_bloat AS (
              -- WHERE NOT is_na
          ) s4
 )
-SELECT
+select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     (select sum(approx_bloat_bytes) from q_bloat) as approx_table_bloat_b,
     ((select sum(approx_bloat_bytes) from q_bloat) * 100 / pg_database_size(current_database()))::int8 as approx_bloat_percentage

--- a/pgwatch2/metrics/table_bloat_approx_summary_sql/9.0/metric.sql
+++ b/pgwatch2/metrics/table_bloat_approx_summary_sql/9.0/metric.sql
@@ -1,7 +1,7 @@
 WITH q_bloat AS (
     select * from get_table_bloat_approx_sql()
 )
-SELECT
+select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     (select sum(approx_bloat_bytes) from q_bloat) as approx_table_bloat_b,
     ((select sum(approx_bloat_bytes) from q_bloat) * 100 / pg_database_size(current_database()))::int8 as approx_bloat_percentage

--- a/pgwatch2/metrics/table_bloat_approx_summary_sql/9.0/metric_su.sql
+++ b/pgwatch2/metrics/table_bloat_approx_summary_sql/9.0/metric_su.sql
@@ -111,7 +111,7 @@ WITH q_bloat AS (
              -- WHERE NOT is_na
          ) s4
 )
-SELECT
+select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     (select sum(approx_bloat_bytes) from q_bloat) as approx_table_bloat_b,
     ((select sum(approx_bloat_bytes) from q_bloat) * 100 / pg_database_size(current_database()))::int8 as approx_bloat_percentage

--- a/pgwatch2/metrics/table_hashes/9.0/metric.sql
+++ b/pgwatch2/metrics/table_hashes/9.0/metric.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   quote_ident(table_schema)||'.'||quote_ident(table_name) as tag_table,
   md5((array_agg((c.*)::text order by ordinal_position))::text)

--- a/pgwatch2/metrics/table_hashes/9.3/metric.sql
+++ b/pgwatch2/metrics/table_hashes/9.3/metric.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   quote_ident(table_schema)||'.'||quote_ident(table_name) as tag_table,
   md5((array_agg((c.*)::text order by ordinal_position))::text)

--- a/pgwatch2/metrics/table_io_stats/9.0/metric.sql
+++ b/pgwatch2/metrics/table_io_stats/9.0/metric.sql
@@ -1,4 +1,4 @@
-SELECT
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   schemaname::text as tag_schema,
   relname::text as tag_table_name,

--- a/pgwatch2/metrics/table_stats/10/metric.sql
+++ b/pgwatch2/metrics/table_stats/10/metric.sql
@@ -58,7 +58,7 @@ with recursive
           and c.relpersistence != 't' -- and temp tables
     )
 
-select
+select /* pgwatch2_generated */
     epoch_ns,
     tag_schema,
     tag_table_name,

--- a/pgwatch2/metrics/table_stats/9.0/metric_master.sql
+++ b/pgwatch2/metrics/table_stats/9.0/metric_master.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   quote_ident(schemaname) as tag_schema,
   quote_ident(ut.relname) as tag_table_name,

--- a/pgwatch2/metrics/table_stats/9.0/metric_standby.sql
+++ b/pgwatch2/metrics/table_stats/9.0/metric_standby.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   quote_ident(schemaname) as tag_schema,
   quote_ident(ut.relname) as tag_table_name,

--- a/pgwatch2/metrics/table_stats/9.1/metric_master.sql
+++ b/pgwatch2/metrics/table_stats/9.1/metric_master.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   quote_ident(schemaname) as tag_schema,
   quote_ident(ut.relname) as tag_table_name,

--- a/pgwatch2/metrics/table_stats/9.1/metric_standby.sql
+++ b/pgwatch2/metrics/table_stats/9.1/metric_standby.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     quote_ident(schemaname) as tag_schema,
     quote_ident(ut.relname) as tag_table_name,

--- a/pgwatch2/metrics/table_stats/9.2/metric.sql
+++ b/pgwatch2/metrics/table_stats/9.2/metric.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   quote_ident(schemaname) as tag_schema,
   quote_ident(ut.relname) as tag_table_name,

--- a/pgwatch2/metrics/table_stats/metric_attrs.yaml
+++ b/pgwatch2/metrics/table_stats/metric_attrs.yaml
@@ -1,0 +1,2 @@
+---
+statement_timeout_seconds: 300

--- a/pgwatch2/metrics/table_stats_approx/10/metric.sql
+++ b/pgwatch2/metrics/table_stats_approx/10/metric.sql
@@ -1,0 +1,152 @@
+with recursive
+    q_root_part as (
+        select c.oid,
+               c.relkind,
+               n.nspname root_schema,
+               c.relname root_relname
+        from pg_class c
+                 join pg_namespace n on n.oid = c.relnamespace
+        where relkind in ('p', 'r')
+          and relpersistence != 't'
+          and not n.nspname like any (array[E'pg\\_%', 'information_schema', E'\\_timescaledb%'])
+          and not exists(select * from pg_inherits where inhrelid = c.oid)
+          and exists(select * from pg_inherits where inhparent = c.oid)
+    ),
+    q_parts (relid, relkind, level, root) as (
+        select oid, relkind, 1, oid
+        from q_root_part
+        union all
+        select inhrelid, c.relkind, level + 1, q.root
+        from pg_inherits i
+                 join q_parts q on inhparent = q.relid
+                 join pg_class c on c.oid = i.inhrelid
+    ),
+    q_tstats as (
+      with q_tbls_by_total_associated_relpages_approx as (
+        select * from (
+          select
+            c.oid,
+            c.relname,
+            c.relpages,
+            coalesce((select sum(relpages) from pg_class ci join pg_index i on i.indexrelid = ci.oid where i.indrelid = c.oid), 0) as index_relpages,
+            coalesce((select coalesce(ct.relpages, 0) + coalesce(cti.relpages, 0) from pg_class ct left join pg_index ti on ti.indrelid = ct.oid left join pg_class cti on cti.oid = ti.indexrelid where ct.oid = c.reltoastrelid), 0) as toast_relpages,
+            case when 'autovacuum_enabled=off' = ANY(c.reloptions) then 1 else 0 end as no_autovacuum,
+            age(c.relfrozenxid) as tx_freeze_age,
+            c.relpersistence      
+          from
+            pg_class c
+            join pg_namespace n on n.oid = c.relnamespace
+          where
+            not n.nspname like any (array[E'pg\\_%', 'information_schema', E'\\_timescaledb%'])
+            and c.relkind = 'r'
+            and c.relpersistence != 't'
+        ) x
+        order by relpages + index_relpages + toast_relpages desc limit 300
+      ), q_block_size as (
+        select current_setting('block_size')::int8 as bs
+      )
+      select /* pgwatch2_generated */
+        (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+        relid,
+        quote_ident(schemaname)||'.'||quote_ident(ut.relname) as tag_table_full_name,
+        bs * relpages as table_size_b,
+        abs(greatest(ceil(log((bs*relpages+1) / 10^6)), 0))::text as tag_table_size_cardinality_mb, -- i.e. 0=<1MB, 1=<10MB, 2=<100MB,..
+        bs * (relpages + index_relpages + toast_relpages) as total_relation_size_b,
+        bs * toast_relpages as toast_size_b,
+        (extract(epoch from now() - greatest(last_vacuum, last_autovacuum)))::int8 as seconds_since_last_vacuum,
+        (extract(epoch from now() - greatest(last_analyze, last_autoanalyze)))::int8 as seconds_since_last_analyze,
+        no_autovacuum,
+        seq_scan,
+        seq_tup_read,
+        coalesce(idx_scan, 0) as idx_scan,
+        coalesce(idx_tup_fetch, 0) as idx_tup_fetch,
+        n_tup_ins,
+        n_tup_upd,
+        n_tup_del,
+        n_tup_hot_upd,
+        n_live_tup,
+        n_dead_tup,
+        vacuum_count,
+        autovacuum_count,
+        analyze_count,
+        autoanalyze_count,
+        tx_freeze_age,
+        relpersistence        
+      from
+        pg_stat_user_tables ut
+        join q_tbls_by_total_associated_relpages_approx t on t.oid = ut.relid
+        join q_block_size on true
+      where
+        -- leaving out fully locked tables as pg_relation_size also wants a lock and would wait
+        not exists (select 1 from pg_locks where relation = relid and mode = 'AccessExclusiveLock')
+      order by relpages desc
+
+    )
+
+select /* pgwatch2_generated */
+    epoch_ns,
+    tag_table_full_name,
+    0 as is_part_root,
+    table_size_b,
+    tag_table_size_cardinality_mb, -- i.e. 0=<1MB, 1=<10MB, 2=<100MB,..
+    total_relation_size_b,
+    toast_size_b,
+    seconds_since_last_vacuum,
+    seconds_since_last_analyze,
+    no_autovacuum,
+    seq_scan,
+    seq_tup_read,
+    idx_scan,
+    idx_tup_fetch,
+    n_tup_ins,
+    n_tup_upd,
+    n_tup_del,
+    n_tup_hot_upd,
+    n_live_tup,
+    n_dead_tup,
+    vacuum_count,
+    autovacuum_count,
+    analyze_count,
+    autoanalyze_count,
+    tx_freeze_age
+from q_tstats
+where not exists (select * from q_root_part where oid = q_tstats.relid)
+
+union all
+
+select * from (
+    select
+        epoch_ns,
+        quote_ident(qr.root_schema) || '.' || quote_ident(qr.root_relname) as tag_table_full_name,
+        1 as is_part_root,
+        sum(table_size_b)::int8 table_size_b,
+        abs(greatest(ceil(log((sum(table_size_b) + 1) / 10 ^ 6)),
+             0))::text as tag_table_size_cardinality_mb, -- i.e. 0=<1MB, 1=<10MB, 2=<100MB,..
+        sum(total_relation_size_b)::int8 total_relation_size_b,
+        sum(toast_size_b)::int8 toast_size_b,
+        min(seconds_since_last_vacuum)::int8 seconds_since_last_vacuum,
+        min(seconds_since_last_analyze)::int8 seconds_since_last_analyze,
+        sum(no_autovacuum)::int8 no_autovacuum,
+        sum(seq_scan)::int8 seq_scan,
+        sum(seq_tup_read)::int8 seq_tup_read,
+        sum(idx_scan)::int8 idx_scan,
+        sum(idx_tup_fetch)::int8 idx_tup_fetch,
+        sum(n_tup_ins)::int8 n_tup_ins,
+        sum(n_tup_upd)::int8 n_tup_upd,
+        sum(n_tup_del)::int8 n_tup_del,
+        sum(n_tup_hot_upd)::int8 n_tup_hot_upd,
+        sum(n_live_tup)::int8 n_live_tup,
+        sum(n_dead_tup)::int8 n_dead_tup,
+        sum(vacuum_count)::int8 vacuum_count,
+        sum(autovacuum_count)::int8 autovacuum_count,
+        sum(analyze_count)::int8 analyze_count,
+        sum(autoanalyze_count)::int8 autoanalyze_count,
+        max(tx_freeze_age)::int8 tx_freeze_age
+      from
+           q_tstats ts
+           join q_parts qp on qp.relid = ts.relid
+           join q_root_part qr on qr.oid = qp.root
+      group by
+           1, 2
+) x
+order by table_size_b desc nulls last limit 300;

--- a/pgwatch2/metrics/table_stats_approx/10/metric.sql
+++ b/pgwatch2/metrics/table_stats_approx/10/metric.sql
@@ -148,5 +148,4 @@ select * from (
            join q_root_part qr on qr.oid = qp.root
       group by
            1, 2
-) x
-order by table_size_b desc nulls last limit 300;
+) x;

--- a/pgwatch2/metrics/table_stats_approx/9.0/metric_master.sql
+++ b/pgwatch2/metrics/table_stats_approx/9.0/metric_master.sql
@@ -47,5 +47,4 @@ from
   join q_block_size on true
 where
   -- leaving out fully locked tables as pg_relation_size also wants a lock and would wait
-  not exists (select 1 from pg_locks where relation = relid and mode = 'AccessExclusiveLock')
-order by relpages desc;
+  not exists (select 1 from pg_locks where relation = relid and mode = 'AccessExclusiveLock');

--- a/pgwatch2/metrics/table_stats_approx/9.0/metric_master.sql
+++ b/pgwatch2/metrics/table_stats_approx/9.0/metric_master.sql
@@ -1,0 +1,51 @@
+with q_tbls_by_total_associated_relpages_approx as (
+  select * from (
+    select
+      c.oid,
+      c.relname,
+      c.relpages,
+      coalesce((select sum(relpages) from pg_class ci join pg_index i on i.indexrelid = ci.oid where i.indrelid = c.oid), 0) as index_relpages,
+      coalesce((select coalesce(ct.relpages, 0) + coalesce(cti.relpages, 0) from pg_class ct left join pg_index ti on ti.indrelid = ct.oid left join pg_class cti on cti.oid = ti.indexrelid where ct.oid = c.reltoastrelid), 0) as toast_relpages,
+      case when 'autovacuum_enabled=off' = ANY(c.reloptions) then 1 else 0 end as no_autovacuum,
+      age(c.relfrozenxid) as tx_freeze_age
+    from
+      pg_class c
+      join pg_namespace n on n.oid = c.relnamespace
+    where
+      not n.nspname like any (array[E'pg\\_%', 'information_schema'])
+      and c.relkind = 'r'
+      and not relistemp -- and temp tables
+  ) x
+  order by relpages + index_relpages + toast_relpages desc limit 300
+), q_block_size as (
+  select current_setting('block_size')::int8 as bs
+)
+select /* pgwatch2_generated */
+  (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+  quote_ident(schemaname)||'.'||quote_ident(ut.relname) as tag_table_full_name,
+  bs * relpages as table_size_b,
+  abs(greatest(ceil(log((bs*relpages+1) / 10^6)), 0))::text as tag_table_size_cardinality_mb, -- i.e. 0=<1MB, 1=<10MB, 2=<100MB,..
+  bs * (relpages + index_relpages + toast_relpages) as total_relation_size_b,
+  bs * toast_relpages as toast_size_b,
+  (extract(epoch from now() - greatest(last_vacuum, last_autovacuum)))::int8 as seconds_since_last_vacuum,
+  (extract(epoch from now() - greatest(last_analyze, last_autoanalyze)))::int8 as seconds_since_last_analyze,
+  no_autovacuum,
+  seq_scan,
+  seq_tup_read,
+  coalesce(idx_scan, 0) as idx_scan,
+  coalesce(idx_tup_fetch, 0) as idx_tup_fetch,
+  n_tup_ins,
+  n_tup_upd,
+  n_tup_del,
+  n_tup_hot_upd,
+  n_live_tup,
+  n_dead_tup,
+  tx_freeze_age
+from
+  pg_stat_user_tables ut
+  join q_tbls_by_total_associated_relpages_approx t on t.oid = ut.relid
+  join q_block_size on true
+where
+  -- leaving out fully locked tables as pg_relation_size also wants a lock and would wait
+  not exists (select 1 from pg_locks where relation = relid and mode = 'AccessExclusiveLock')
+order by relpages desc;

--- a/pgwatch2/metrics/table_stats_approx/9.0/metric_standby.sql
+++ b/pgwatch2/metrics/table_stats_approx/9.0/metric_standby.sql
@@ -1,0 +1,49 @@
+with q_tbls_by_total_associated_relpages_approx as (
+  select * from (
+    select
+      c.oid,
+      c.relname,
+      c.relpages,
+      coalesce((select sum(relpages) from pg_class ci join pg_index i on i.indexrelid = ci.oid where i.indrelid = c.oid), 0) as index_relpages,
+      coalesce((select coalesce(ct.relpages, 0) + coalesce(cti.relpages, 0) from pg_class ct left join pg_index ti on ti.indrelid = ct.oid left join pg_class cti on cti.oid = ti.indexrelid where ct.oid = c.reltoastrelid), 0) as toast_relpages,
+      case when 'autovacuum_enabled=off' = ANY(c.reloptions) then 1 else 0 end as no_autovacuum
+    from
+      pg_class c
+      join pg_namespace n on n.oid = c.relnamespace
+    where
+      not n.nspname like any (array[E'pg\\_%', 'information_schema'])
+      and c.relkind = 'r'
+      and not relistemp -- and temp tables
+  ) x
+  order by relpages + index_relpages + toast_relpages desc limit 300
+), q_block_size as (
+  select current_setting('block_size')::int8 as bs
+)
+select /* pgwatch2_generated */
+  (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+  quote_ident(schemaname)||'.'||quote_ident(ut.relname) as tag_table_full_name,
+  bs * relpages as table_size_b,
+  abs(greatest(ceil(log((bs*relpages+1) / 10^6)), 0))::text as tag_table_size_cardinality_mb, -- i.e. 0=<1MB, 1=<10MB, 2=<100MB,..
+  bs * (relpages + index_relpages + toast_relpages) as total_relation_size_b,
+  bs * toast_relpages as toast_size_b,
+  (extract(epoch from now() - greatest(last_vacuum, last_autovacuum)))::int8 as seconds_since_last_vacuum,
+  (extract(epoch from now() - greatest(last_analyze, last_autoanalyze)))::int8 as seconds_since_last_analyze,
+  no_autovacuum,
+  seq_scan,
+  seq_tup_read,
+  coalesce(idx_scan, 0) as idx_scan,
+  coalesce(idx_tup_fetch, 0) as idx_tup_fetch,
+  n_tup_ins,
+  n_tup_upd,
+  n_tup_del,
+  n_tup_hot_upd,
+  n_live_tup,
+  n_dead_tup
+from
+  pg_stat_user_tables ut
+  join q_tbls_by_total_associated_relpages_approx t on t.oid = ut.relid
+  join q_block_size on true
+where
+  -- leaving out fully locked tables as pg_relation_size also wants a lock and would wait
+  not exists (select 1 from pg_locks where relation = relid and mode = 'AccessExclusiveLock')
+order by relpages desc;

--- a/pgwatch2/metrics/table_stats_approx/9.0/metric_standby.sql
+++ b/pgwatch2/metrics/table_stats_approx/9.0/metric_standby.sql
@@ -45,5 +45,4 @@ from
   join q_block_size on true
 where
   -- leaving out fully locked tables as pg_relation_size also wants a lock and would wait
-  not exists (select 1 from pg_locks where relation = relid and mode = 'AccessExclusiveLock')
-order by relpages desc;
+  not exists (select 1 from pg_locks where relation = relid and mode = 'AccessExclusiveLock');

--- a/pgwatch2/metrics/table_stats_approx/9.1/metric_master.sql
+++ b/pgwatch2/metrics/table_stats_approx/9.1/metric_master.sql
@@ -1,0 +1,38 @@
+select /* pgwatch2_generated */
+  (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+  quote_ident(schemaname) as tag_schema,
+  quote_ident(ut.relname) as tag_table_name,
+  quote_ident(schemaname)||'.'||quote_ident(ut.relname) as tag_table_full_name,
+  pg_table_size(relid) as table_size_b,
+  abs(greatest(ceil(log((pg_table_size(relid)+1) / 10^6)), 0))::text as tag_table_size_cardinality_mb, -- i.e. 0=<1MB, 1=<10MB, 2=<100MB,..
+  pg_total_relation_size(relid) as total_relation_size_b,
+  case when reltoastrelid != 0 then pg_total_relation_size(reltoastrelid) else 0::int8 end as toast_size_b,
+  (extract(epoch from now() - greatest(last_vacuum, last_autovacuum)))::int8 as seconds_since_last_vacuum,
+  (extract(epoch from now() - greatest(last_analyze, last_autoanalyze)))::int8 as seconds_since_last_analyze,
+  case when 'autovacuum_enabled=off' = ANY(c.reloptions) then 1 else 0 end as no_autovacuum,
+  seq_scan,
+  seq_tup_read,
+  coalesce(idx_scan, 0) as idx_scan,
+  coalesce(idx_tup_fetch, 0) as idx_tup_fetch,
+  n_tup_ins,
+  n_tup_upd,
+  n_tup_del,
+  n_tup_hot_upd,
+  n_live_tup,
+  n_dead_tup,
+  vacuum_count,
+  autovacuum_count,
+  analyze_count,
+  autoanalyze_count,
+  age(relfrozenxid) as tx_freeze_age,
+  relpersistence
+from
+  pg_stat_user_tables ut
+  join
+  pg_class c on c.oid = ut.relid
+where
+  -- leaving out fully locked tables as pg_relation_size also wants a lock and would wait
+  not exists (select 1 from pg_locks where relation = relid and mode = 'AccessExclusiveLock')
+  and c.relpersistence != 't' -- and temp tables
+order by table_size_b desc nulls last limit 300;
+

--- a/pgwatch2/metrics/table_stats_approx/9.1/metric_master.sql
+++ b/pgwatch2/metrics/table_stats_approx/9.1/metric_master.sql
@@ -1,15 +1,36 @@
+with q_tbls_by_total_associated_relpages_approx as (
+  select * from (
+    select
+      c.oid,
+      c.relname,
+      c.relpages,
+      coalesce((select sum(relpages) from pg_class ci join pg_index i on i.indexrelid = ci.oid where i.indrelid = c.oid), 0) as index_relpages,
+      coalesce((select coalesce(ct.relpages, 0) + coalesce(cti.relpages, 0) from pg_class ct left join pg_index ti on ti.indrelid = ct.oid left join pg_class cti on cti.oid = ti.indexrelid where ct.oid = c.reltoastrelid), 0) as toast_relpages,
+      case when 'autovacuum_enabled=off' = ANY(c.reloptions) then 1 else 0 end as no_autovacuum,
+      age(c.relfrozenxid) as tx_freeze_age,
+      c.relpersistence
+    from
+      pg_class c
+      join pg_namespace n on n.oid = c.relnamespace
+    where
+      not n.nspname like any (array[E'pg\\_%', 'information_schema'])
+      and c.relkind = 'r'
+      and c.relpersistence != 't'
+  ) x
+  order by relpages + index_relpages + toast_relpages desc limit 300
+), q_block_size as (
+  select current_setting('block_size')::int8 as bs
+)
 select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
-  quote_ident(schemaname) as tag_schema,
-  quote_ident(ut.relname) as tag_table_name,
   quote_ident(schemaname)||'.'||quote_ident(ut.relname) as tag_table_full_name,
-  pg_table_size(relid) as table_size_b,
-  abs(greatest(ceil(log((pg_table_size(relid)+1) / 10^6)), 0))::text as tag_table_size_cardinality_mb, -- i.e. 0=<1MB, 1=<10MB, 2=<100MB,..
-  pg_total_relation_size(relid) as total_relation_size_b,
-  case when reltoastrelid != 0 then pg_total_relation_size(reltoastrelid) else 0::int8 end as toast_size_b,
+  bs * relpages as table_size_b,
+  abs(greatest(ceil(log((bs*relpages+1) / 10^6)), 0))::text as tag_table_size_cardinality_mb, -- i.e. 0=<1MB, 1=<10MB, 2=<100MB,..
+  bs * (relpages + index_relpages + toast_relpages) as total_relation_size_b,
+  bs * toast_relpages as toast_size_b,
   (extract(epoch from now() - greatest(last_vacuum, last_autovacuum)))::int8 as seconds_since_last_vacuum,
   (extract(epoch from now() - greatest(last_analyze, last_autoanalyze)))::int8 as seconds_since_last_analyze,
-  case when 'autovacuum_enabled=off' = ANY(c.reloptions) then 1 else 0 end as no_autovacuum,
+  no_autovacuum,
   seq_scan,
   seq_tup_read,
   coalesce(idx_scan, 0) as idx_scan,
@@ -24,15 +45,12 @@ select /* pgwatch2_generated */
   autovacuum_count,
   analyze_count,
   autoanalyze_count,
-  age(relfrozenxid) as tx_freeze_age,
+  tx_freeze_age,
   relpersistence
 from
   pg_stat_user_tables ut
-  join
-  pg_class c on c.oid = ut.relid
+  join q_tbls_by_total_associated_relpages_approx t on t.oid = ut.relid
+  join q_block_size on true
 where
   -- leaving out fully locked tables as pg_relation_size also wants a lock and would wait
-  not exists (select 1 from pg_locks where relation = relid and mode = 'AccessExclusiveLock')
-  and c.relpersistence != 't' -- and temp tables
-order by table_size_b desc nulls last limit 300;
-
+  not exists (select 1 from pg_locks where relation = relid and mode = 'AccessExclusiveLock');

--- a/pgwatch2/metrics/table_stats_approx/9.1/metric_standby.sql
+++ b/pgwatch2/metrics/table_stats_approx/9.1/metric_standby.sql
@@ -1,0 +1,36 @@
+select /* pgwatch2_generated */
+    (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+    quote_ident(schemaname) as tag_schema,
+    quote_ident(ut.relname) as tag_table_name,
+    quote_ident(schemaname)||'.'||quote_ident(ut.relname) as tag_table_full_name,
+    pg_table_size(relid) as table_size_b,
+    abs(greatest(ceil(log((pg_table_size(relid)+1) / 10^6)), 0))::text as tag_table_size_cardinality_mb, -- i.e. 0=<1MB, 1=<10MB, 2=<100MB,..
+    pg_total_relation_size(relid) as total_relation_size_b,
+    case when reltoastrelid != 0 then pg_total_relation_size(reltoastrelid) else 0::int8 end as toast_size_b,
+    (extract(epoch from now() - greatest(last_vacuum, last_autovacuum)))::int8 as seconds_since_last_vacuum,
+    (extract(epoch from now() - greatest(last_analyze, last_autoanalyze)))::int8 as seconds_since_last_analyze,
+    case when 'autovacuum_enabled=off' = ANY(c.reloptions) then 1 else 0 end as no_autovacuum,
+    seq_scan,
+    seq_tup_read,
+    coalesce(idx_scan, 0) as idx_scan,
+    coalesce(idx_tup_fetch, 0) as idx_tup_fetch,
+    n_tup_ins,
+    n_tup_upd,
+    n_tup_del,
+    n_tup_hot_upd,
+    n_live_tup,
+    n_dead_tup,
+    vacuum_count,
+    autovacuum_count,
+    analyze_count,
+    autoanalyze_count,
+    relpersistence
+from
+    pg_stat_user_tables ut
+        join
+    pg_class c on c.oid = ut.relid
+where
+  -- leaving out fully locked tables as pg_relation_size also wants a lock and would wait
+    not exists (select 1 from pg_locks where relation = relid and mode = 'AccessExclusiveLock')
+  and c.relpersistence != 't' -- and temp tables
+order by table_size_b desc nulls last limit 300;

--- a/pgwatch2/metrics/table_stats_approx/9.1/metric_standby.sql
+++ b/pgwatch2/metrics/table_stats_approx/9.1/metric_standby.sql
@@ -1,36 +1,54 @@
+with q_tbls_by_total_associated_relpages_approx as (
+  select * from (
+    select
+      c.oid,
+      c.relname,
+      c.relpages,
+      coalesce((select sum(relpages) from pg_class ci join pg_index i on i.indexrelid = ci.oid where i.indrelid = c.oid), 0) as index_relpages,
+      coalesce((select coalesce(ct.relpages, 0) + coalesce(cti.relpages, 0) from pg_class ct left join pg_index ti on ti.indrelid = ct.oid left join pg_class cti on cti.oid = ti.indexrelid where ct.oid = c.reltoastrelid), 0) as toast_relpages,
+      case when 'autovacuum_enabled=off' = ANY(c.reloptions) then 1 else 0 end as no_autovacuum,
+      c.relpersistence
+    from
+      pg_class c
+      join pg_namespace n on n.oid = c.relnamespace
+    where
+      not n.nspname like any (array[E'pg\\_%', 'information_schema'])
+      and c.relkind = 'r'
+      and c.relpersistence != 't'
+  ) x
+  order by relpages + index_relpages + toast_relpages desc limit 300
+), q_block_size as (
+  select current_setting('block_size')::int8 as bs
+)
 select /* pgwatch2_generated */
-    (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
-    quote_ident(schemaname) as tag_schema,
-    quote_ident(ut.relname) as tag_table_name,
-    quote_ident(schemaname)||'.'||quote_ident(ut.relname) as tag_table_full_name,
-    pg_table_size(relid) as table_size_b,
-    abs(greatest(ceil(log((pg_table_size(relid)+1) / 10^6)), 0))::text as tag_table_size_cardinality_mb, -- i.e. 0=<1MB, 1=<10MB, 2=<100MB,..
-    pg_total_relation_size(relid) as total_relation_size_b,
-    case when reltoastrelid != 0 then pg_total_relation_size(reltoastrelid) else 0::int8 end as toast_size_b,
-    (extract(epoch from now() - greatest(last_vacuum, last_autovacuum)))::int8 as seconds_since_last_vacuum,
-    (extract(epoch from now() - greatest(last_analyze, last_autoanalyze)))::int8 as seconds_since_last_analyze,
-    case when 'autovacuum_enabled=off' = ANY(c.reloptions) then 1 else 0 end as no_autovacuum,
-    seq_scan,
-    seq_tup_read,
-    coalesce(idx_scan, 0) as idx_scan,
-    coalesce(idx_tup_fetch, 0) as idx_tup_fetch,
-    n_tup_ins,
-    n_tup_upd,
-    n_tup_del,
-    n_tup_hot_upd,
-    n_live_tup,
-    n_dead_tup,
-    vacuum_count,
-    autovacuum_count,
-    analyze_count,
-    autoanalyze_count,
-    relpersistence
+  (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+  quote_ident(schemaname)||'.'||quote_ident(ut.relname) as tag_table_full_name,
+  bs * relpages as table_size_b,
+  abs(greatest(ceil(log((bs*relpages+1) / 10^6)), 0))::text as tag_table_size_cardinality_mb, -- i.e. 0=<1MB, 1=<10MB, 2=<100MB,..
+  bs * (relpages + index_relpages + toast_relpages) as total_relation_size_b,
+  bs * toast_relpages as toast_size_b,
+  (extract(epoch from now() - greatest(last_vacuum, last_autovacuum)))::int8 as seconds_since_last_vacuum,
+  (extract(epoch from now() - greatest(last_analyze, last_autoanalyze)))::int8 as seconds_since_last_analyze,
+  no_autovacuum,
+  seq_scan,
+  seq_tup_read,
+  coalesce(idx_scan, 0) as idx_scan,
+  coalesce(idx_tup_fetch, 0) as idx_tup_fetch,
+  n_tup_ins,
+  n_tup_upd,
+  n_tup_del,
+  n_tup_hot_upd,
+  n_live_tup,
+  n_dead_tup,
+  vacuum_count,
+  autovacuum_count,
+  analyze_count,
+  autoanalyze_count,
+  relpersistence
 from
-    pg_stat_user_tables ut
-        join
-    pg_class c on c.oid = ut.relid
+  pg_stat_user_tables ut
+  join q_tbls_by_total_associated_relpages_approx t on t.oid = ut.relid
+  join q_block_size on true
 where
   -- leaving out fully locked tables as pg_relation_size also wants a lock and would wait
-    not exists (select 1 from pg_locks where relation = relid and mode = 'AccessExclusiveLock')
-  and c.relpersistence != 't' -- and temp tables
-order by table_size_b desc nulls last limit 300;
+  not exists (select 1 from pg_locks where relation = relid and mode = 'AccessExclusiveLock');

--- a/pgwatch2/metrics/table_stats_approx/9.2/metric.sql
+++ b/pgwatch2/metrics/table_stats_approx/9.2/metric.sql
@@ -8,7 +8,7 @@ with q_tbls_by_total_associated_relpages_approx as (
       coalesce((select coalesce(ct.relpages, 0) + coalesce(cti.relpages, 0) from pg_class ct left join pg_index ti on ti.indrelid = ct.oid left join pg_class cti on cti.oid = ti.indexrelid where ct.oid = c.reltoastrelid), 0) as toast_relpages,
       case when 'autovacuum_enabled=off' = ANY(c.reloptions) then 1 else 0 end as no_autovacuum,
       age(c.relfrozenxid) as tx_freeze_age,
-      c.relpersistence      
+      c.relpersistence
     from
       pg_class c
       join pg_namespace n on n.oid = c.relnamespace
@@ -46,12 +46,11 @@ select /* pgwatch2_generated */
   analyze_count,
   autoanalyze_count,
   tx_freeze_age,
-  relpersistence        
+  relpersistence
 from
   pg_stat_user_tables ut
   join q_tbls_by_total_associated_relpages_approx t on t.oid = ut.relid
   join q_block_size on true
 where
   -- leaving out fully locked tables as pg_relation_size also wants a lock and would wait
-  not exists (select 1 from pg_locks where relation = relid and mode = 'AccessExclusiveLock')
-order by relpages desc;
+  not exists (select 1 from pg_locks where relation = relid and mode = 'AccessExclusiveLock');

--- a/pgwatch2/metrics/table_stats_approx/9.2/metric.sql
+++ b/pgwatch2/metrics/table_stats_approx/9.2/metric.sql
@@ -1,0 +1,57 @@
+with q_tbls_by_total_associated_relpages_approx as (
+  select * from (
+    select
+      c.oid,
+      c.relname,
+      c.relpages,
+      coalesce((select sum(relpages) from pg_class ci join pg_index i on i.indexrelid = ci.oid where i.indrelid = c.oid), 0) as index_relpages,
+      coalesce((select coalesce(ct.relpages, 0) + coalesce(cti.relpages, 0) from pg_class ct left join pg_index ti on ti.indrelid = ct.oid left join pg_class cti on cti.oid = ti.indexrelid where ct.oid = c.reltoastrelid), 0) as toast_relpages,
+      case when 'autovacuum_enabled=off' = ANY(c.reloptions) then 1 else 0 end as no_autovacuum,
+      age(c.relfrozenxid) as tx_freeze_age,
+      c.relpersistence      
+    from
+      pg_class c
+      join pg_namespace n on n.oid = c.relnamespace
+    where
+      not n.nspname like any (array[E'pg\\_%', 'information_schema'])
+      and c.relkind = 'r'
+      and c.relpersistence != 't'
+  ) x
+  order by relpages + index_relpages + toast_relpages desc limit 300
+), q_block_size as (
+  select current_setting('block_size')::int8 as bs
+)
+select /* pgwatch2_generated */
+  (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+  quote_ident(schemaname)||'.'||quote_ident(ut.relname) as tag_table_full_name,
+  bs * relpages as table_size_b,
+  abs(greatest(ceil(log((bs*relpages+1) / 10^6)), 0))::text as tag_table_size_cardinality_mb, -- i.e. 0=<1MB, 1=<10MB, 2=<100MB,..
+  bs * (relpages + index_relpages + toast_relpages) as total_relation_size_b,
+  bs * toast_relpages as toast_size_b,
+  (extract(epoch from now() - greatest(last_vacuum, last_autovacuum)))::int8 as seconds_since_last_vacuum,
+  (extract(epoch from now() - greatest(last_analyze, last_autoanalyze)))::int8 as seconds_since_last_analyze,
+  no_autovacuum,
+  seq_scan,
+  seq_tup_read,
+  coalesce(idx_scan, 0) as idx_scan,
+  coalesce(idx_tup_fetch, 0) as idx_tup_fetch,
+  n_tup_ins,
+  n_tup_upd,
+  n_tup_del,
+  n_tup_hot_upd,
+  n_live_tup,
+  n_dead_tup,
+  vacuum_count,
+  autovacuum_count,
+  analyze_count,
+  autoanalyze_count,
+  tx_freeze_age,
+  relpersistence        
+from
+  pg_stat_user_tables ut
+  join q_tbls_by_total_associated_relpages_approx t on t.oid = ut.relid
+  join q_block_size on true
+where
+  -- leaving out fully locked tables as pg_relation_size also wants a lock and would wait
+  not exists (select 1 from pg_locks where relation = relid and mode = 'AccessExclusiveLock')
+order by relpages desc;

--- a/pgwatch2/metrics/table_stats_approx/column_attrs.yaml
+++ b/pgwatch2/metrics/table_stats_approx/column_attrs.yaml
@@ -1,0 +1,10 @@
+---
+prometheus_gauge_columns:
+  - table_size_b
+  - total_relation_size_b
+  - toast_size_b
+  - seconds_since_last_vacuum
+  - seconds_since_last_analyze
+  - n_live_tup
+  - n_dead_tup
+prometheus_ignored_columns:

--- a/pgwatch2/metrics/table_stats_approx/metric_attrs.yaml
+++ b/pgwatch2/metrics/table_stats_approx/metric_attrs.yaml
@@ -1,0 +1,2 @@
+---
+metric_storage_name: table_stat

--- a/pgwatch2/metrics/table_stats_approx/metric_attrs.yaml
+++ b/pgwatch2/metrics/table_stats_approx/metric_attrs.yaml
@@ -1,2 +1,2 @@
 ---
-metric_storage_name: table_stat
+metric_storage_name: table_stats

--- a/pgwatch2/metrics/vmstat/9.1/metric.sql
+++ b/pgwatch2/metrics/vmstat/9.1/metric.sql
@@ -1,4 +1,4 @@
-SELECT
+select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     r, b, swpd, free, buff, cache, si, so, bi, bo, "in", cs, us, sy, id, wa, st, cpu_count, load_1m, load_5m, load_15m, total_memory
 from

--- a/pgwatch2/metrics/wait_events/9.6/metric.sql
+++ b/pgwatch2/metrics/wait_events/9.6/metric.sql
@@ -1,7 +1,7 @@
 with q_sa as (
     select * from pg_stat_activity where datname = current_database() and pid <> pg_backend_pid()
 )
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   wait_event_type as tag_wait_event_type,
   wait_event as tag_wait_event,

--- a/pgwatch2/metrics/wait_events/9.6/metric.sql
+++ b/pgwatch2/metrics/wait_events/9.6/metric.sql
@@ -6,12 +6,14 @@ select
   wait_event_type as tag_wait_event_type,
   wait_event as tag_wait_event,
   count(*),
-  case when wait_event_type is not null then avg(abs(1e6* extract(epoch from now() - query_start)))::int8 else null end as avg_query_duration_us,
+  avg(abs(1e6* extract(epoch from now() - query_start)))::int8 as avg_query_duration_us,
+  max(abs(1e6* extract(epoch from now() - query_start)))::int8 as max_query_duration_us,
   (select count(*) from q_sa where state = 'active') as total_active
 from
   q_sa
 where
   state = 'active'
   and wait_event_type is not null
+  and wait_event_type <> 'Timeout'
 group by
   1, 2, 3;

--- a/pgwatch2/metrics/wait_events/9.6/metric.sql
+++ b/pgwatch2/metrics/wait_events/9.6/metric.sql
@@ -1,0 +1,17 @@
+with q_sa as (
+    select * from pg_stat_activity where datname = current_database() and pid <> pg_backend_pid()
+)
+select
+  (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+  wait_event_type as tag_wait_event_type,
+  wait_event as tag_wait_event,
+  count(*),
+  case when wait_event_type is not null then avg(abs(1e6* extract(epoch from now() - query_start)))::int8 else null end as avg_query_duration_us,
+  (select count(*) from q_sa where state = 'active') as total_active
+from
+  q_sa
+where
+  state = 'active'
+  and wait_event_type is not null
+group by
+  1, 2, 3;

--- a/pgwatch2/metrics/wal/10/metric.sql
+++ b/pgwatch2/metrics/wal/10/metric.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   case
     when pg_is_in_recovery() = false then

--- a/pgwatch2/metrics/wal/10/metric_su.sql
+++ b/pgwatch2/metrics/wal/10/metric_su.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   case
     when pg_is_in_recovery() = false then

--- a/pgwatch2/metrics/wal/9.2/metric.sql
+++ b/pgwatch2/metrics/wal/9.2/metric.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   case
     when pg_is_in_recovery() = false then

--- a/pgwatch2/metrics/wal_receiver/10/metric_standby.sql
+++ b/pgwatch2/metrics/wal_receiver/10/metric_standby.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   pg_wal_lsn_diff(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn())::int8 as replay_lag_b,
   extract(epoch from (now() - pg_last_xact_replay_timestamp()))::int8 as last_replay_s;

--- a/pgwatch2/metrics/wal_receiver/9.2/metric_standby.sql
+++ b/pgwatch2/metrics/wal_receiver/9.2/metric_standby.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   pg_xlog_location_diff(pg_last_xlog_receive_location(), pg_last_xlog_replay_location())::int8 as replay_lag_b,
   extract(epoch from (now() - pg_last_xact_replay_timestamp()))::int8 as last_replay_s;

--- a/pgwatch2/metrics/wal_size/10/metric.sql
+++ b/pgwatch2/metrics/wal_size/10/metric.sql
@@ -1,3 +1,3 @@
-select
+select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     get_wal_size() as wal_size_b;

--- a/pgwatch2/metrics/wal_size/10/metric_su.sql
+++ b/pgwatch2/metrics/wal_size/10/metric_su.sql
@@ -1,7 +1,7 @@
 /* NB! If using not a real superuser but a role with "pg_monitor" grant then below execute grant is needed:
   GRANT EXECUTE ON FUNCTION pg_stat_file(text) to pgwatch2;
 */
-select
+select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     (sum((pg_stat_file('pg_wal/' || name)).size))::int8 as wal_size_b
 from pg_ls_waldir();

--- a/pgwatch2/metrics/wal_size/9.0/metric.sql
+++ b/pgwatch2/metrics/wal_size/9.0/metric.sql
@@ -1,3 +1,3 @@
-select
+select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     get_wal_size() as wal_size_b;

--- a/pgwatch2/metrics/wal_size/9.0/metric_su.sql
+++ b/pgwatch2/metrics/wal_size/9.0/metric_su.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     sum((pg_stat_file('pg_xlog/'||f)).size)::int8 as wal_size_b from (select pg_ls_dir('pg_xlog') f) ls
 ;

--- a/pgwatch2/metrics/wal_stats/14/metric.sql
+++ b/pgwatch2/metrics/wal_stats/14/metric.sql
@@ -1,0 +1,12 @@
+select
+    (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+    wal_records,
+    wal_fpi,
+    (wal_bytes / 1024)::int8 as wal_bytes_kb,
+    wal_buffers_full,
+    wal_write,
+    wal_sync,
+    wal_write_time::int8,
+    wal_sync_time::int8
+from
+    pg_stat_wal;

--- a/pgwatch2/metrics/wal_stats/14/metric.sql
+++ b/pgwatch2/metrics/wal_stats/14/metric.sql
@@ -1,4 +1,4 @@
-select
+select /* pgwatch2_generated */
     (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
     wal_records,
     wal_fpi,

--- a/pgwatch2/pgwatch2.go
+++ b/pgwatch2/pgwatch2.go
@@ -638,7 +638,7 @@ func DBExecRead(conn *sqlx.DB, host_ident, sql string, args ...interface{}) ([](
 	return ret, err
 }
 
-func DBExecInReadOnlyTX(conn *sqlx.DB, host_ident, sql string, args ...interface{}) ([](map[string]interface{}), error) {
+func DBExecInExplicitTX(conn *sqlx.DB, host_ident, sql string, args ...interface{}) ([](map[string]interface{}), error) {
 	ret := make([]map[string]interface{}, 0)
 	var rows *sqlx.Rows
 	var err error
@@ -648,7 +648,7 @@ func DBExecInReadOnlyTX(conn *sqlx.DB, host_ident, sql string, args ...interface
 	}
 
 	ctx := context.Background()
-	txOpts := go_sql.TxOptions{ReadOnly: true}
+	txOpts := go_sql.TxOptions{}
 
 	tx, err := conn.BeginTxx(ctx, &txOpts)
 	if err != nil {
@@ -737,7 +737,7 @@ func DBExecReadByDbUniqueName(dbUnique, metricName string, stmtTimeoutOverride i
 	//log.Debugf("Executing SQL: %s", sqlToExec)
 	t1 := time.Now()
 	if useConnPooling {
-		data, err = DBExecInReadOnlyTX(conn, dbUnique, sqlToExec, args...)
+		data, err = DBExecInExplicitTX(conn, dbUnique, sqlToExec, args...)
 	} else {
 		data, err = DBExecRead(conn, dbUnique, sqlToExec, args...)
 	}

--- a/pgwatch2/pgwatch2.go
+++ b/pgwatch2/pgwatch2.go
@@ -2085,7 +2085,7 @@ func DBGetPGVersion(dbUnique string, dbType string, noCache bool) (DBVersionMapE
 			} else {
 				matches := rBouncerAndPgpoolVerMatch.FindStringSubmatch(data[0]["version"].(string))
 				if len(matches) != 1 {
-					log.Errorf("Unexpected PgBouncer version input: %s", data[0]["version"].(string))
+					log.Errorf("[%s] Unexpected PgBouncer version input: %s", dbUnique, data[0]["version"].(string))
 					return ver, fmt.Errorf("Unexpected PgBouncer version input: %s", data[0]["version"].(string))
 				}
 				verNew.VersionStr = matches[0]
@@ -2102,7 +2102,7 @@ func DBGetPGVersion(dbUnique string, dbType string, noCache bool) (DBVersionMapE
 			} else {
 				matches := rBouncerAndPgpoolVerMatch.FindStringSubmatch(string(data[0]["pool_version"].([]byte)))
 				if len(matches) != 1 {
-					log.Errorf("Unexpected PgPool version input: %s", data[0]["pool_version"].([]byte))
+					log.Errorf("[%s] Unexpected PgPool version input: %s", dbUnique, data[0]["pool_version"].([]byte))
 					return ver, fmt.Errorf("Unexpected PgPool version input: %s", data[0]["pool_version"].([]byte))
 				}
 				verNew.VersionStr = matches[0]
@@ -2114,7 +2114,7 @@ func DBGetPGVersion(dbUnique string, dbType string, noCache bool) (DBVersionMapE
 				if noCache {
 					return ver, err
 				} else {
-					log.Info("DBGetPGVersion failed, using old cached value. err:", err)
+					log.Infof("[%s] DBGetPGVersion failed, using old cached value. err: %v", dbUnique, err)
 					return ver, nil
 				}
 			}

--- a/pgwatch2/pgwatch2.go
+++ b/pgwatch2/pgwatch2.go
@@ -3035,7 +3035,7 @@ func FetchMetrics(msg MetricFetchMessage, host_state map[string]map[string]strin
 			subsMetricName := msg.MetricName + "_approx"
 			mvp_approx, err := GetMetricVersionProperties(subsMetricName, vme, nil)
 			if err == nil && mvp_approx.MetricAttrs.MetricStorageName == msg.MetricName {
-				log.Warningf("[%s:%s] Transparently swapping metric to %s due to hard-coded rules...", msg.DBUniqueName, msg.MetricName, subsMetricName)
+				log.Infof("[%s:%s] Transparently swapping metric to %s due to hard-coded rules...", msg.DBUniqueName, msg.MetricName, subsMetricName)
 				msg.MetricName = subsMetricName
 			}
 		}

--- a/pgwatch2/pgwatch2.go
+++ b/pgwatch2/pgwatch2.go
@@ -543,13 +543,15 @@ func CloseOrLimitSqlConnPoolForMonitoredDBIfAny(dbUnique string) {
 		return
 	}
 
-	if (IsDBUndersized(dbUnique) || IsDBIgnoredBasedOnRecoveryState(dbUnique)) && useConnPooling {
+	if IsDBUndersized(dbUnique) || IsDBIgnoredBasedOnRecoveryState(dbUnique) {
 
-		s := conn.Stats()
-		if s.MaxOpenConnections > 1 {
-			log.Debugf("[%s] Limiting SQL connection pool to max 1 connection due to dormant state ...", dbUnique)
-			conn.SetMaxIdleConns(1)
-			conn.SetMaxOpenConns(1)
+		if useConnPooling {
+			s := conn.Stats()
+			if s.MaxOpenConnections > 1 {
+				log.Debugf("[%s] Limiting SQL connection pool to max 1 connection due to dormant state ...", dbUnique)
+				conn.SetMaxIdleConns(1)
+				conn.SetMaxOpenConns(1)
+			}
 		}
 
 	} else { // removed from config

--- a/pgwatch2/pgwatch2.go
+++ b/pgwatch2/pgwatch2.go
@@ -2125,7 +2125,6 @@ func GetDBTotalApproxSize(dbUnique string) (int64, error) {
 		current_setting('block_size')::int8 * sum(relpages) as db_size_approx
 	from
 		pg_class c
-		join pg_namespace n on n.oid = c.relnamespace
 	where	/* NB! works only for v9.1+*/
 		c.relpersistence != 't';
 	`

--- a/pgwatch2/pgwatch2.go
+++ b/pgwatch2/pgwatch2.go
@@ -634,6 +634,7 @@ func DBExecReadByDbUniqueName(dbUnique, metricName string, stmtTimeoutOverride i
 	var duration time.Duration
 	var exists bool
 	var sqlStmtTimeout string
+	var sqlLockTimeout = "SET lock_timeout TO '5s';"
 
 	if strings.TrimSpace(sql) == "" {
 		return nil, errors.New("empty SQL"), duration
@@ -668,7 +669,7 @@ func DBExecReadByDbUniqueName(dbUnique, metricName string, stmtTimeoutOverride i
 	}
 
 	t1 := time.Now()
-	data, err := DBExecRead(conn, dbUnique, sqlStmtTimeout+sql, args...)
+	data, err := DBExecRead(conn, dbUnique, sqlLockTimeout+sqlStmtTimeout+sql, args...)
 	t2 := time.Now()
 	if err != nil {
 		atomic.AddUint64(&totalMetricFetchFailuresCounter, 1)

--- a/pgwatch2/pgwatch2.go
+++ b/pgwatch2/pgwatch2.go
@@ -4939,7 +4939,7 @@ type Options struct {
 	ServersRefreshLoopSeconds    int    `long:"servers-refresh-loop-seconds" description:"Sleep time for the main loop" env:"PW2_SERVERS_REFRESH_LOOP_SECONDS" default:"120"`
 	InstanceLevelCacheMaxSeconds int64  `long:"instance-level-cache-max-seconds" description:"Max allowed staleness for instance level metric data shared between DBs of an instance. Affects 'continuous' host types only. Set to 0 to disable" env:"PW2_INSTANCE_LEVEL_CACHE_MAX_SECONDS" default:"30"`
 	MinDbSizeMB                  int64  `long:"min-db-size-mb" description:"Smaller size DBs will be ignored and not monitored until they reach the threshold." env:"PW2_MIN_DB_SIZE_MB" default:"0"`
-	MaxParallelConnectionsPerDb  int    `long:"max-parallel-connections-per-db" description:"Max parallel metric fetches per DB. Note the multiplication effect on multi-DB instances" default:"2"`
+	MaxParallelConnectionsPerDb  int    `long:"max-parallel-connections-per-db" description:"Max parallel metric fetches per DB. Note the multiplication effect on multi-DB instances" env:"PW2_MAX_PARALLEL_CONNECTIONS_PER_DB" default:"2"`
 	Version                      bool   `long:"version" description:"Show Git build version and exit" env:"PW2_VERSION"`
 	Ping                         bool   `long:"ping" description:"Try to connect to all configured DB-s, report errors and then exit" env:"PW2_PING"`
 }

--- a/pgwatch2/prom.go
+++ b/pgwatch2/prom.go
@@ -132,7 +132,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 func setInstanceUpDownState(ch chan<- prometheus.Metric, md MonitoredDatabase) {
 	log.Debugf("checking availability of configured DB [%s:%s]...", md.DBUniqueName, PROM_INSTANCE_UP_STATE_METRIC)
-	vme, err := DBGetPGVersion(md.DBUniqueName, md.DBType, true)
+	vme, err := DBGetPGVersion(md.DBUniqueName, md.DBType, !promAsyncMode) // NB! in async mode 2min cache can mask smaller downtimes!
 	data := make(map[string]interface{})
 	if err != nil {
 		data[PROM_INSTANCE_UP_STATE_METRIC] = 0

--- a/pgwatch2/prom.go
+++ b/pgwatch2/prom.go
@@ -87,7 +87,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 				if promAsyncMode {
 					promAsyncMetricCacheLock.RLock()
-					metricStoreMessages, ok = promAsyncMetricCache[md.DBUniqueName+metric]
+					metricStoreMessages, ok = promAsyncMetricCache[md.DBUniqueName][metric]
 					promAsyncMetricCacheLock.RUnlock()
 					if !ok {
 						log.Debugf("[%s:%s] could not find data from the prom cache. maybe gathering interval not yet reached or zero rows returned, ignoring", md.DBUniqueName, metric)

--- a/pgwatch2/prom.go
+++ b/pgwatch2/prom.go
@@ -20,6 +20,9 @@ type Exporter struct {
 
 const PROM_INSTANCE_UP_STATE_METRIC = "instance_up"
 
+// timestamps older than that will be ignored on the Prom scraper side anyways, so better don't emit at all and just log a notice
+const PROM_SCRAPING_STALENESS_HARD_DROP_LIMIT = time.Minute * time.Duration(10)
+
 func NewExporter() (*Exporter, error) {
 	return &Exporter{
 		lastScrapeErrors: prometheus.NewGauge(prometheus.GaugeOpts{
@@ -179,6 +182,7 @@ func MetricStoreMessageToPromMetrics(msg MetricStoreMessage) []prometheus.Metric
 
 	var epoch_time time.Time
 	var epoch_ns int64
+	var epoch_now time.Time = time.Now()
 
 	if len(msg.Data) == 0 {
 		return promMetrics
@@ -192,6 +196,12 @@ func MetricStoreMessageToPromMetrics(msg MetricStoreMessage) []prometheus.Metric
 		epoch_time = time.Now()
 	} else {
 		epoch_time = time.Unix(0, epoch_ns)
+
+		if promAsyncMode && epoch_time.Before(epoch_now.Add(-1*PROM_SCRAPING_STALENESS_HARD_DROP_LIMIT)) {
+			log.Warningf("[%s][%s] Dropping metric set due to staleness (>%v) ...", msg.DBUniqueName, msg.MetricName, PROM_SCRAPING_STALENESS_HARD_DROP_LIMIT)
+			PurgeMetricsFromPromAsyncCacheIfAny(msg.DBUniqueName, msg.MetricName)
+			return promMetrics
+		}
 	}
 
 	for _, dr := range msg.Data {

--- a/pgwatch2/sql/config_store/metric_definitions.sql
+++ b/pgwatch2/sql/config_store/metric_definitions.sql
@@ -626,6 +626,87 @@ $sql$,
 '{"prometheus_gauge_columns": ["numbackends", "postmaster_uptime_s", "backup_duration_s", "checksum_last_failure_s"]}'
 );
 
+insert into pgwatch2.metric(m_name, m_pg_version_from, m_sql, m_sql_su, m_column_attrs)
+values (
+'db_stats',
+14,
+$sql$
+select
+  (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+  numbackends,
+  xact_commit,
+  xact_rollback,
+  blks_read,
+  blks_hit,
+  tup_returned,
+  tup_fetched,
+  tup_inserted,
+  tup_updated,
+  tup_deleted,
+  conflicts,
+  temp_files,
+  temp_bytes,
+  deadlocks,
+  blk_read_time,
+  blk_write_time,
+  extract(epoch from (now() - pg_postmaster_start_time()))::int8 as postmaster_uptime_s,
+  extract(epoch from (now() - pg_backup_start_time()))::int8 as backup_duration_s,
+  checksum_failures,
+  extract(epoch from (now() - checksum_last_failure))::int8 as checksum_last_failure_s,
+  case when pg_is_in_recovery() then 1 else 0 end as in_recovery_int,
+  system_identifier::text as tag_sys_id,
+  session_time::int8,
+  active_time::int8,
+  idle_in_transaction_time::int8,
+  sessions,
+  sessions_abandoned,
+  sessions_fatal,
+  sessions_killed
+from
+  pg_stat_database, pg_control_system()
+where
+  datname = current_database();
+$sql$,
+$sql$
+select
+  (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+  numbackends,
+  xact_commit,
+  xact_rollback,
+  blks_read,
+  blks_hit,
+  tup_returned,
+  tup_fetched,
+  tup_inserted,
+  tup_updated,
+  tup_deleted,
+  conflicts,
+  temp_files,
+  temp_bytes,
+  deadlocks,
+  blk_read_time,
+  blk_write_time,
+  extract(epoch from (now() - coalesce((pg_stat_file('postmaster.pid', true)).modification, pg_postmaster_start_time())))::int8 as postmaster_uptime_s,
+  extract(epoch from (now() - pg_backup_start_time()))::int8 as backup_duration_s,
+  checksum_failures,
+  extract(epoch from (now() - checksum_last_failure))::int8 as checksum_last_failure_s,
+  case when pg_is_in_recovery() then 1 else 0 end as in_recovery_int,
+  system_identifier::text as tag_sys_id,
+  session_time::int8,
+  active_time::int8,
+  idle_in_transaction_time::int8,
+  sessions,
+  sessions_abandoned,
+  sessions_fatal,
+  sessions_killed
+from
+  pg_stat_database, pg_control_system()
+where
+  datname = current_database();
+$sql$,
+'{"prometheus_gauge_columns": ["numbackends", "postmaster_uptime_s", "backup_duration_s", "checksum_last_failure_s"]}'
+);
+
 insert into pgwatch2.metric(m_name, m_pg_version_from, m_sql, m_column_attrs)
 values (
 'db_stats_aurora',
@@ -6727,6 +6808,48 @@ select
   (select round(100.0 * coalesce(max(last_value::numeric / max_value), 0), 2)::float from q_seq_data where not cycle) as max_used_pct,
   (select count(*) from q_seq_data where not cycle and last_value::numeric / max_value > 0.5) as p50_used_seq_count,
   (select count(*) from q_seq_data where not cycle and last_value::numeric / max_value > 0.75) as p75_used_seq_count;
+$sql$
+);
+
+insert into pgwatch2.metric(m_name, m_pg_version_from, m_sql, m_sql_su)
+values (
+'replication_slot_stats',
+14,
+$sql$
+select
+  (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+  slot_name::text as tag_slot_name,
+  spill_txns,
+  spill_count,
+  spill_bytes,
+  stream_txns,
+  stream_count,
+  stream_bytes,
+  total_txns,
+  total_bytes
+from
+  pg_stat_replication_slots;
+$sql$
+);
+
+
+insert into pgwatch2.metric(m_name, m_pg_version_from, m_sql, m_sql_su)
+values (
+'wal_stats',
+14,
+$sql$
+select
+    (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+    wal_records,
+    wal_fpi,
+    (wal_bytes / 1024)::int8 as wal_bytes_kb,
+    wal_buffers_full,
+    wal_write,
+    wal_sync,
+    wal_write_time::int8,
+    wal_sync_time::int8
+from
+    pg_stat_wal;
 $sql$
 );
 

--- a/pgwatch2/sql/config_store/metric_definitions.sql
+++ b/pgwatch2/sql/config_store/metric_definitions.sql
@@ -783,7 +783,8 @@ values (
 $sql$
 select
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
-  pg_database_size(current_database()) as size_b;
+  pg_database_size(current_database()) as size_b,
+  (select sum(pg_total_relation_size(oid)) from pg_class where relkind = 'r' and relname LIKE E'pg\\_%') as catalog_size_b;
 $sql$,
 '{"prometheus_all_gauge_columns": true}'
 );

--- a/pgwatch2/sql/config_store/metric_definitions.sql
+++ b/pgwatch2/sql/config_store/metric_definitions.sql
@@ -784,7 +784,10 @@ $sql$
 select
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   pg_database_size(current_database()) as size_b,
-  (select sum(pg_total_relation_size(oid)) from pg_class where relkind = 'r' and relname LIKE E'pg\\_%') as catalog_size_b;
+  (select sum(pg_total_relation_size(c.oid))::int8
+   from pg_class c join pg_namespace n on n.oid = c.relnamespace
+   where nspname = 'pg_catalog' and relkind = 'r'
+  ) as catalog_size_b;
 $sql$,
 '{"prometheus_all_gauge_columns": true}'
 );

--- a/pgwatch2/sql/config_store/metric_definitions.sql
+++ b/pgwatch2/sql/config_store/metric_definitions.sql
@@ -6854,6 +6854,32 @@ $sql$
 );
 
 
+insert into pgwatch2.metric(m_name, m_pg_version_from, m_sql)
+values (
+'wait_events',
+14,
+$sql$
+  with q_sa as (
+      select * from pg_stat_activity where datname = current_database() and pid <> pg_backend_pid()
+  )
+  select
+    (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+    wait_event_type as tag_wait_event_type,
+    wait_event as tag_wait_event,
+    count(*),
+    case when wait_event_type is not null then avg(abs(1e6* extract(epoch from now() - query_start)))::int8 else null end as avg_query_duration_us,
+    (select count(*) from q_sa where state = 'active') as total_active
+  from
+    q_sa
+  where
+    state = 'active'
+    and wait_event_type is not null
+  group by
+    1, 2, 3;
+$sql$
+);
+
+
 /* Metric attributes */
 -- truncate pgwatch2.metric_attribute;
 

--- a/pgwatch2/sql/config_store/metric_definitions.sql
+++ b/pgwatch2/sql/config_store/metric_definitions.sql
@@ -792,6 +792,35 @@ $sql$,
 '{"prometheus_all_gauge_columns": true}'
 );
 
+/* db_size_approx */
+
+insert into pgwatch2.metric(m_name, m_pg_version_from, m_sql, m_column_attrs)
+values (
+'db_size_approx',
+9.1,
+$sql$
+select /* pgwatch2_generated */
+  (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+  current_setting('block_size')::int8 * (
+    select sum(relpages) from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+    where c.relpersistence != 't'
+  ) as size_b,
+  current_setting('block_size')::int8 * (
+    select sum(c.relpages + coalesce(ct.relpages, 0) + coalesce(cti.relpages, 0))
+    from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+    left join pg_class ct on ct.oid = c.reltoastrelid
+    left join pg_index ti on ti.indrelid = ct.oid
+    left join pg_class cti on cti.oid = ti.indexrelid
+    where nspname = 'pg_catalog'
+    and (c.relkind = 'r'
+      or c.relkind = 'i' and not c.relname ~ '^pg_toast')
+  ) as catalog_size_b;
+$sql$,
+'{"prometheus_all_gauge_columns": true}'
+);
+
 /* index_stats */
 
 insert into pgwatch2.metric(m_name, m_pg_version_from, m_sql, m_column_attrs)
@@ -2087,6 +2116,484 @@ order by table_size_b desc nulls last limit 300;
 $sql$,
 '{"prometheus_gauge_columns": ["table_size_b", "total_relation_size_b", "toast_size_b", "seconds_since_last_vacuum", "seconds_since_last_analyze", "n_live_tup", "n_dead_tup"]}'
 );
+
+/* table_stats_approx */
+
+insert into pgwatch2.metric(m_name, m_pg_version_from, m_sql, m_column_attrs, m_master_only)
+values (
+'table_stats_approx',
+9.0,
+$sql$
+with q_tbls_by_total_associated_relpages_approx as (
+  select * from (
+    select
+      c.oid,
+      c.relname,
+      c.relpages,
+      coalesce((select sum(relpages) from pg_class ci join pg_index i on i.indexrelid = ci.oid where i.indrelid = c.oid), 0) as index_relpages,
+      coalesce((select coalesce(ct.relpages, 0) + coalesce(cti.relpages, 0) from pg_class ct left join pg_index ti on ti.indrelid = ct.oid left join pg_class cti on cti.oid = ti.indexrelid where ct.oid = c.reltoastrelid), 0) as toast_relpages,
+      case when 'autovacuum_enabled=off' = ANY(c.reloptions) then 1 else 0 end as no_autovacuum,
+      age(c.relfrozenxid) as tx_freeze_age
+    from
+      pg_class c
+      join pg_namespace n on n.oid = c.relnamespace
+    where
+      not n.nspname like any (array[E'pg\\_%', 'information_schema'])
+      and c.relkind = 'r'
+      and not relistemp -- and temp tables
+  ) x
+  order by relpages + index_relpages + toast_relpages desc limit 300
+), q_block_size as (
+  select current_setting('block_size')::int8 as bs
+)
+select /* pgwatch2_generated */
+  (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+  quote_ident(schemaname)||'.'||quote_ident(ut.relname) as tag_table_full_name,
+  bs * relpages as table_size_b,
+  abs(greatest(ceil(log((bs*relpages+1) / 10^6)), 0))::text as tag_table_size_cardinality_mb, -- i.e. 0=<1MB, 1=<10MB, 2=<100MB,..
+  bs * (relpages + index_relpages + toast_relpages) as total_relation_size_b,
+  bs * toast_relpages as toast_size_b,
+  (extract(epoch from now() - greatest(last_vacuum, last_autovacuum)))::int8 as seconds_since_last_vacuum,
+  (extract(epoch from now() - greatest(last_analyze, last_autoanalyze)))::int8 as seconds_since_last_analyze,
+  no_autovacuum,
+  seq_scan,
+  seq_tup_read,
+  coalesce(idx_scan, 0) as idx_scan,
+  coalesce(idx_tup_fetch, 0) as idx_tup_fetch,
+  n_tup_ins,
+  n_tup_upd,
+  n_tup_del,
+  n_tup_hot_upd,
+  n_live_tup,
+  n_dead_tup,
+  tx_freeze_age
+from
+  pg_stat_user_tables ut
+  join q_tbls_by_total_associated_relpages_approx t on t.oid = ut.relid
+  join q_block_size on true
+where
+  -- leaving out fully locked tables as pg_relation_size also wants a lock and would wait
+  not exists (select 1 from pg_locks where relation = relid and mode = 'AccessExclusiveLock');
+$sql$,
+'{"prometheus_gauge_columns": ["table_size_b", "total_relation_size_b", "toast_size_b", "seconds_since_last_vacuum", "seconds_since_last_analyze", "n_live_tup", "n_dead_tup"]}',
+true
+);
+
+insert into pgwatch2.metric(m_name, m_pg_version_from, m_sql, m_column_attrs, m_standby_only)
+values (
+'table_stats_approx',
+9.0,
+$sql$
+with q_tbls_by_total_associated_relpages_approx as (
+  select * from (
+    select
+      c.oid,
+      c.relname,
+      c.relpages,
+      coalesce((select sum(relpages) from pg_class ci join pg_index i on i.indexrelid = ci.oid where i.indrelid = c.oid), 0) as index_relpages,
+      coalesce((select coalesce(ct.relpages, 0) + coalesce(cti.relpages, 0) from pg_class ct left join pg_index ti on ti.indrelid = ct.oid left join pg_class cti on cti.oid = ti.indexrelid where ct.oid = c.reltoastrelid), 0) as toast_relpages,
+      case when 'autovacuum_enabled=off' = ANY(c.reloptions) then 1 else 0 end as no_autovacuum
+    from
+      pg_class c
+      join pg_namespace n on n.oid = c.relnamespace
+    where
+      not n.nspname like any (array[E'pg\\_%', 'information_schema'])
+      and c.relkind = 'r'
+      and not relistemp -- and temp tables
+  ) x
+  order by relpages + index_relpages + toast_relpages desc limit 300
+), q_block_size as (
+  select current_setting('block_size')::int8 as bs
+)
+select /* pgwatch2_generated */
+  (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+  quote_ident(schemaname)||'.'||quote_ident(ut.relname) as tag_table_full_name,
+  bs * relpages as table_size_b,
+  abs(greatest(ceil(log((bs*relpages+1) / 10^6)), 0))::text as tag_table_size_cardinality_mb, -- i.e. 0=<1MB, 1=<10MB, 2=<100MB,..
+  bs * (relpages + index_relpages + toast_relpages) as total_relation_size_b,
+  bs * toast_relpages as toast_size_b,
+  (extract(epoch from now() - greatest(last_vacuum, last_autovacuum)))::int8 as seconds_since_last_vacuum,
+  (extract(epoch from now() - greatest(last_analyze, last_autoanalyze)))::int8 as seconds_since_last_analyze,
+  no_autovacuum,
+  seq_scan,
+  seq_tup_read,
+  coalesce(idx_scan, 0) as idx_scan,
+  coalesce(idx_tup_fetch, 0) as idx_tup_fetch,
+  n_tup_ins,
+  n_tup_upd,
+  n_tup_del,
+  n_tup_hot_upd,
+  n_live_tup,
+  n_dead_tup
+from
+  pg_stat_user_tables ut
+  join q_tbls_by_total_associated_relpages_approx t on t.oid = ut.relid
+  join q_block_size on true
+where
+  -- leaving out fully locked tables as pg_relation_size also wants a lock and would wait
+  not exists (select 1 from pg_locks where relation = relid and mode = 'AccessExclusiveLock');
+$sql$,
+'{"prometheus_gauge_columns": ["table_size_b", "total_relation_size_b", "toast_size_b", "seconds_since_last_vacuum", "seconds_since_last_analyze", "n_live_tup", "n_dead_tup"]}',
+true
+);
+
+insert into pgwatch2.metric(m_name, m_pg_version_from, m_sql, m_column_attrs, m_master_only)
+values (
+'table_stats_approx',
+9.1,
+$sql$
+with q_tbls_by_total_associated_relpages_approx as (
+  select * from (
+    select
+      c.oid,
+      c.relname,
+      c.relpages,
+      coalesce((select sum(relpages) from pg_class ci join pg_index i on i.indexrelid = ci.oid where i.indrelid = c.oid), 0) as index_relpages,
+      coalesce((select coalesce(ct.relpages, 0) + coalesce(cti.relpages, 0) from pg_class ct left join pg_index ti on ti.indrelid = ct.oid left join pg_class cti on cti.oid = ti.indexrelid where ct.oid = c.reltoastrelid), 0) as toast_relpages,
+      case when 'autovacuum_enabled=off' = ANY(c.reloptions) then 1 else 0 end as no_autovacuum,
+      age(c.relfrozenxid) as tx_freeze_age,
+      c.relpersistence
+    from
+      pg_class c
+      join pg_namespace n on n.oid = c.relnamespace
+    where
+      not n.nspname like any (array[E'pg\\_%', 'information_schema'])
+      and c.relkind = 'r'
+      and c.relpersistence != 't'
+  ) x
+  order by relpages + index_relpages + toast_relpages desc limit 300
+), q_block_size as (
+  select current_setting('block_size')::int8 as bs
+)
+select /* pgwatch2_generated */
+  (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+  quote_ident(schemaname)||'.'||quote_ident(ut.relname) as tag_table_full_name,
+  bs * relpages as table_size_b,
+  abs(greatest(ceil(log((bs*relpages+1) / 10^6)), 0))::text as tag_table_size_cardinality_mb, -- i.e. 0=<1MB, 1=<10MB, 2=<100MB,..
+  bs * (relpages + index_relpages + toast_relpages) as total_relation_size_b,
+  bs * toast_relpages as toast_size_b,
+  (extract(epoch from now() - greatest(last_vacuum, last_autovacuum)))::int8 as seconds_since_last_vacuum,
+  (extract(epoch from now() - greatest(last_analyze, last_autoanalyze)))::int8 as seconds_since_last_analyze,
+  no_autovacuum,
+  seq_scan,
+  seq_tup_read,
+  coalesce(idx_scan, 0) as idx_scan,
+  coalesce(idx_tup_fetch, 0) as idx_tup_fetch,
+  n_tup_ins,
+  n_tup_upd,
+  n_tup_del,
+  n_tup_hot_upd,
+  n_live_tup,
+  n_dead_tup,
+  vacuum_count,
+  autovacuum_count,
+  analyze_count,
+  autoanalyze_count,
+  tx_freeze_age,
+  relpersistence
+from
+  pg_stat_user_tables ut
+  join q_tbls_by_total_associated_relpages_approx t on t.oid = ut.relid
+  join q_block_size on true
+where
+  -- leaving out fully locked tables as pg_relation_size also wants a lock and would wait
+  not exists (select 1 from pg_locks where relation = relid and mode = 'AccessExclusiveLock');
+$sql$,
+'{"prometheus_gauge_columns": ["table_size_b", "total_relation_size_b", "toast_size_b", "seconds_since_last_vacuum", "seconds_since_last_analyze", "n_live_tup", "n_dead_tup"]}',
+true
+);
+
+insert into pgwatch2.metric(m_name, m_pg_version_from, m_sql, m_column_attrs, m_standby_only)
+values (
+'table_stats_approx',
+9.1,
+$sql$
+with q_tbls_by_total_associated_relpages_approx as (
+  select * from (
+    select
+      c.oid,
+      c.relname,
+      c.relpages,
+      coalesce((select sum(relpages) from pg_class ci join pg_index i on i.indexrelid = ci.oid where i.indrelid = c.oid), 0) as index_relpages,
+      coalesce((select coalesce(ct.relpages, 0) + coalesce(cti.relpages, 0) from pg_class ct left join pg_index ti on ti.indrelid = ct.oid left join pg_class cti on cti.oid = ti.indexrelid where ct.oid = c.reltoastrelid), 0) as toast_relpages,
+      case when 'autovacuum_enabled=off' = ANY(c.reloptions) then 1 else 0 end as no_autovacuum,
+      c.relpersistence
+    from
+      pg_class c
+      join pg_namespace n on n.oid = c.relnamespace
+    where
+      not n.nspname like any (array[E'pg\\_%', 'information_schema'])
+      and c.relkind = 'r'
+      and c.relpersistence != 't'
+  ) x
+  order by relpages + index_relpages + toast_relpages desc limit 300
+), q_block_size as (
+  select current_setting('block_size')::int8 as bs
+)
+select /* pgwatch2_generated */
+  (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+  quote_ident(schemaname)||'.'||quote_ident(ut.relname) as tag_table_full_name,
+  bs * relpages as table_size_b,
+  abs(greatest(ceil(log((bs*relpages+1) / 10^6)), 0))::text as tag_table_size_cardinality_mb, -- i.e. 0=<1MB, 1=<10MB, 2=<100MB,..
+  bs * (relpages + index_relpages + toast_relpages) as total_relation_size_b,
+  bs * toast_relpages as toast_size_b,
+  (extract(epoch from now() - greatest(last_vacuum, last_autovacuum)))::int8 as seconds_since_last_vacuum,
+  (extract(epoch from now() - greatest(last_analyze, last_autoanalyze)))::int8 as seconds_since_last_analyze,
+  no_autovacuum,
+  seq_scan,
+  seq_tup_read,
+  coalesce(idx_scan, 0) as idx_scan,
+  coalesce(idx_tup_fetch, 0) as idx_tup_fetch,
+  n_tup_ins,
+  n_tup_upd,
+  n_tup_del,
+  n_tup_hot_upd,
+  n_live_tup,
+  n_dead_tup,
+  vacuum_count,
+  autovacuum_count,
+  analyze_count,
+  autoanalyze_count,
+  relpersistence
+from
+  pg_stat_user_tables ut
+  join q_tbls_by_total_associated_relpages_approx t on t.oid = ut.relid
+  join q_block_size on true
+where
+  -- leaving out fully locked tables as pg_relation_size also wants a lock and would wait
+  not exists (select 1 from pg_locks where relation = relid and mode = 'AccessExclusiveLock');
+$sql$,
+'{"prometheus_gauge_columns": ["table_size_b", "total_relation_size_b", "toast_size_b", "seconds_since_last_vacuum", "seconds_since_last_analyze", "n_live_tup", "n_dead_tup"]}',
+true
+);
+
+
+insert into pgwatch2.metric(m_name, m_pg_version_from, m_sql, m_column_attrs)
+values (
+'table_stats_approx',
+9.2,
+$sql$
+with q_tbls_by_total_associated_relpages_approx as (
+  select * from (
+    select
+      c.oid,
+      c.relname,
+      c.relpages,
+      coalesce((select sum(relpages) from pg_class ci join pg_index i on i.indexrelid = ci.oid where i.indrelid = c.oid), 0) as index_relpages,
+      coalesce((select coalesce(ct.relpages, 0) + coalesce(cti.relpages, 0) from pg_class ct left join pg_index ti on ti.indrelid = ct.oid left join pg_class cti on cti.oid = ti.indexrelid where ct.oid = c.reltoastrelid), 0) as toast_relpages,
+      case when 'autovacuum_enabled=off' = ANY(c.reloptions) then 1 else 0 end as no_autovacuum,
+      age(c.relfrozenxid) as tx_freeze_age,
+      c.relpersistence
+    from
+      pg_class c
+      join pg_namespace n on n.oid = c.relnamespace
+    where
+      not n.nspname like any (array[E'pg\\_%', 'information_schema'])
+      and c.relkind = 'r'
+      and c.relpersistence != 't'
+  ) x
+  order by relpages + index_relpages + toast_relpages desc limit 300
+), q_block_size as (
+  select current_setting('block_size')::int8 as bs
+)
+select /* pgwatch2_generated */
+  (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+  quote_ident(schemaname)||'.'||quote_ident(ut.relname) as tag_table_full_name,
+  bs * relpages as table_size_b,
+  abs(greatest(ceil(log((bs*relpages+1) / 10^6)), 0))::text as tag_table_size_cardinality_mb, -- i.e. 0=<1MB, 1=<10MB, 2=<100MB,..
+  bs * (relpages + index_relpages + toast_relpages) as total_relation_size_b,
+  bs * toast_relpages as toast_size_b,
+  (extract(epoch from now() - greatest(last_vacuum, last_autovacuum)))::int8 as seconds_since_last_vacuum,
+  (extract(epoch from now() - greatest(last_analyze, last_autoanalyze)))::int8 as seconds_since_last_analyze,
+  no_autovacuum,
+  seq_scan,
+  seq_tup_read,
+  coalesce(idx_scan, 0) as idx_scan,
+  coalesce(idx_tup_fetch, 0) as idx_tup_fetch,
+  n_tup_ins,
+  n_tup_upd,
+  n_tup_del,
+  n_tup_hot_upd,
+  n_live_tup,
+  n_dead_tup,
+  vacuum_count,
+  autovacuum_count,
+  analyze_count,
+  autoanalyze_count,
+  tx_freeze_age,
+  relpersistence
+from
+  pg_stat_user_tables ut
+  join q_tbls_by_total_associated_relpages_approx t on t.oid = ut.relid
+  join q_block_size on true
+where
+  -- leaving out fully locked tables as pg_relation_size also wants a lock and would wait
+  not exists (select 1 from pg_locks where relation = relid and mode = 'AccessExclusiveLock');
+$sql$,
+'{"prometheus_gauge_columns": ["table_size_b", "total_relation_size_b", "toast_size_b", "seconds_since_last_vacuum", "seconds_since_last_analyze", "n_live_tup", "n_dead_tup"]}'
+);
+
+
+insert into pgwatch2.metric(m_name, m_pg_version_from, m_sql, m_column_attrs)
+values (
+'table_stats_approx',
+10,
+$sql$
+with recursive
+    q_root_part as (
+        select c.oid,
+               c.relkind,
+               n.nspname root_schema,
+               c.relname root_relname
+        from pg_class c
+                 join pg_namespace n on n.oid = c.relnamespace
+        where relkind in ('p', 'r')
+          and relpersistence != 't'
+          and not n.nspname like any (array[E'pg\\_%', 'information_schema', E'\\_timescaledb%'])
+          and not exists(select * from pg_inherits where inhrelid = c.oid)
+          and exists(select * from pg_inherits where inhparent = c.oid)
+    ),
+    q_parts (relid, relkind, level, root) as (
+        select oid, relkind, 1, oid
+        from q_root_part
+        union all
+        select inhrelid, c.relkind, level + 1, q.root
+        from pg_inherits i
+                 join q_parts q on inhparent = q.relid
+                 join pg_class c on c.oid = i.inhrelid
+    ),
+    q_tstats as (
+      with q_tbls_by_total_associated_relpages_approx as (
+        select * from (
+          select
+            c.oid,
+            c.relname,
+            c.relpages,
+            coalesce((select sum(relpages) from pg_class ci join pg_index i on i.indexrelid = ci.oid where i.indrelid = c.oid), 0) as index_relpages,
+            coalesce((select coalesce(ct.relpages, 0) + coalesce(cti.relpages, 0) from pg_class ct left join pg_index ti on ti.indrelid = ct.oid left join pg_class cti on cti.oid = ti.indexrelid where ct.oid = c.reltoastrelid), 0) as toast_relpages,
+            case when 'autovacuum_enabled=off' = ANY(c.reloptions) then 1 else 0 end as no_autovacuum,
+            age(c.relfrozenxid) as tx_freeze_age,
+            c.relpersistence
+          from
+            pg_class c
+            join pg_namespace n on n.oid = c.relnamespace
+          where
+            not n.nspname like any (array[E'pg\\_%', 'information_schema', E'\\_timescaledb%'])
+            and c.relkind = 'r'
+            and c.relpersistence != 't'
+        ) x
+        order by relpages + index_relpages + toast_relpages desc limit 300
+      ), q_block_size as (
+        select current_setting('block_size')::int8 as bs
+      )
+      select /* pgwatch2_generated */
+        (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+        relid,
+        quote_ident(schemaname)||'.'||quote_ident(ut.relname) as tag_table_full_name,
+        bs * relpages as table_size_b,
+        abs(greatest(ceil(log((bs*relpages+1) / 10^6)), 0))::text as tag_table_size_cardinality_mb, -- i.e. 0=<1MB, 1=<10MB, 2=<100MB,..
+        bs * (relpages + index_relpages + toast_relpages) as total_relation_size_b,
+        bs * toast_relpages as toast_size_b,
+        (extract(epoch from now() - greatest(last_vacuum, last_autovacuum)))::int8 as seconds_since_last_vacuum,
+        (extract(epoch from now() - greatest(last_analyze, last_autoanalyze)))::int8 as seconds_since_last_analyze,
+        no_autovacuum,
+        seq_scan,
+        seq_tup_read,
+        coalesce(idx_scan, 0) as idx_scan,
+        coalesce(idx_tup_fetch, 0) as idx_tup_fetch,
+        n_tup_ins,
+        n_tup_upd,
+        n_tup_del,
+        n_tup_hot_upd,
+        n_live_tup,
+        n_dead_tup,
+        vacuum_count,
+        autovacuum_count,
+        analyze_count,
+        autoanalyze_count,
+        tx_freeze_age,
+        relpersistence
+      from
+        pg_stat_user_tables ut
+        join q_tbls_by_total_associated_relpages_approx t on t.oid = ut.relid
+        join q_block_size on true
+      where
+        -- leaving out fully locked tables as pg_relation_size also wants a lock and would wait
+        not exists (select 1 from pg_locks where relation = relid and mode = 'AccessExclusiveLock')
+      order by relpages desc
+
+    )
+
+select /* pgwatch2_generated */
+    epoch_ns,
+    tag_table_full_name,
+    0 as is_part_root,
+    table_size_b,
+    tag_table_size_cardinality_mb, -- i.e. 0=<1MB, 1=<10MB, 2=<100MB,..
+    total_relation_size_b,
+    toast_size_b,
+    seconds_since_last_vacuum,
+    seconds_since_last_analyze,
+    no_autovacuum,
+    seq_scan,
+    seq_tup_read,
+    idx_scan,
+    idx_tup_fetch,
+    n_tup_ins,
+    n_tup_upd,
+    n_tup_del,
+    n_tup_hot_upd,
+    n_live_tup,
+    n_dead_tup,
+    vacuum_count,
+    autovacuum_count,
+    analyze_count,
+    autoanalyze_count,
+    tx_freeze_age
+from q_tstats
+where not exists (select * from q_root_part where oid = q_tstats.relid)
+
+union all
+
+select * from (
+    select
+        epoch_ns,
+        quote_ident(qr.root_schema) || '.' || quote_ident(qr.root_relname) as tag_table_full_name,
+        1 as is_part_root,
+        sum(table_size_b)::int8 table_size_b,
+        abs(greatest(ceil(log((sum(table_size_b) + 1) / 10 ^ 6)),
+             0))::text as tag_table_size_cardinality_mb, -- i.e. 0=<1MB, 1=<10MB, 2=<100MB,..
+        sum(total_relation_size_b)::int8 total_relation_size_b,
+        sum(toast_size_b)::int8 toast_size_b,
+        min(seconds_since_last_vacuum)::int8 seconds_since_last_vacuum,
+        min(seconds_since_last_analyze)::int8 seconds_since_last_analyze,
+        sum(no_autovacuum)::int8 no_autovacuum,
+        sum(seq_scan)::int8 seq_scan,
+        sum(seq_tup_read)::int8 seq_tup_read,
+        sum(idx_scan)::int8 idx_scan,
+        sum(idx_tup_fetch)::int8 idx_tup_fetch,
+        sum(n_tup_ins)::int8 n_tup_ins,
+        sum(n_tup_upd)::int8 n_tup_upd,
+        sum(n_tup_del)::int8 n_tup_del,
+        sum(n_tup_hot_upd)::int8 n_tup_hot_upd,
+        sum(n_live_tup)::int8 n_live_tup,
+        sum(n_dead_tup)::int8 n_dead_tup,
+        sum(vacuum_count)::int8 vacuum_count,
+        sum(autovacuum_count)::int8 autovacuum_count,
+        sum(analyze_count)::int8 analyze_count,
+        sum(autoanalyze_count)::int8 autoanalyze_count,
+        max(tx_freeze_age)::int8 tx_freeze_age
+      from
+           q_tstats ts
+           join q_parts qp on qp.relid = ts.relid
+           join q_root_part qr on qr.oid = qp.root
+      group by
+           1, 2
+) x;
+$sql$,
+'{"prometheus_gauge_columns": ["table_size_b", "total_relation_size_b", "toast_size_b", "seconds_since_last_vacuum", "seconds_since_last_analyze", "n_live_tup", "n_dead_tup"]}'
+);
+
 
 /* wal */
 
@@ -6911,6 +7418,16 @@ insert into pgwatch2.metric_attribute (ma_metric_name, ma_metric_attrs)
 select 'db_stats_aurora', '{"metric_storage_name": "db_stats"}'
 on conflict (ma_metric_name)
 do update set ma_metric_attrs = pgwatch2.metric_attribute.ma_metric_attrs || '{"metric_storage_name": "db_stats"}', ma_last_modified_on = now();
+
+insert into pgwatch2.metric_attribute (ma_metric_name, ma_metric_attrs)
+select 'db_size_approx', '{"metric_storage_name": "db_size_approx"}'
+on conflict (ma_metric_name)
+do update set ma_metric_attrs = pgwatch2.metric_attribute.ma_metric_attrs || '{"metric_storage_name": "db_size_approx"}', ma_last_modified_on = now();
+
+insert into pgwatch2.metric_attribute (ma_metric_name, ma_metric_attrs)
+select 'table_stats_approx', '{"metric_storage_name": "table_stats"}'
+on conflict (ma_metric_name)
+do update set ma_metric_attrs = pgwatch2.metric_attribute.ma_metric_attrs || '{"metric_storage_name": "table_stats"}', ma_last_modified_on = now();
 
 insert into pgwatch2.metric_attribute (ma_metric_name, ma_metric_attrs)
 select 'reco_add_index', '{"extension_version_based_overrides": [{"target_metric": "reco_add_index_ext_qualstats_2.0", "expected_extension_versions": [{"ext_name": "pg_qualstats", "ext_min_version": "2.0"}] }]}'

--- a/pgwatch2/sql/config_store/metric_definitions.sql
+++ b/pgwatch2/sql/config_store/metric_definitions.sql
@@ -6857,7 +6857,7 @@ $sql$
 insert into pgwatch2.metric(m_name, m_pg_version_from, m_sql)
 values (
 'wait_events',
-14,
+9.6,
 $sql$
   with q_sa as (
       select * from pg_stat_activity where datname = current_database() and pid <> pg_backend_pid()
@@ -6867,13 +6867,15 @@ $sql$
     wait_event_type as tag_wait_event_type,
     wait_event as tag_wait_event,
     count(*),
-    case when wait_event_type is not null then avg(abs(1e6* extract(epoch from now() - query_start)))::int8 else null end as avg_query_duration_us,
+    avg(abs(1e6* extract(epoch from now() - query_start)))::int8 as avg_query_duration_us,
+    max(abs(1e6* extract(epoch from now() - query_start)))::int8 as max_query_duration_us,
     (select count(*) from q_sa where state = 'active') as total_active
   from
     q_sa
   where
     state = 'active'
     and wait_event_type is not null
+    and wait_event_type <> 'Timeout'
   group by
     1, 2, 3;
 $sql$


### PR DESCRIPTION
Seems like a lot of stuff but should be no breaking changes. Main things added:

* Some new "approximate size" metrics that skip the real file-system backed functions
* Use approximate table / DB sizes automatically for bigger (1TB+) managed Azure Single Server instances due to FS lag
* New --emergency-pause-triggerfile flag to make it possible to pause all metrics gathering outside of normal automation / deployment
* New --no-helper-functions flag to ignore all metrics relying on 'get_smth()' functions and try the SU version instead. Tuned for managed instances.
* New --try-create-listed-exts-if-missing flag to to try to auto-create popular extensions outside of the helpers system that is not applicable on public clouds
* Better Prometheus mode cache and connection pool handling