### PR TITLE
Metrics: add "wal.timeline" column to be able to detect failovers

### DIFF
--- a/pgwatch2/metrics/wal/10/metric.sql
+++ b/pgwatch2/metrics/wal/10/metric.sql
@@ -8,5 +8,11 @@ select /* pgwatch2_generated */
     end as xlog_location_b,
   case when pg_is_in_recovery() then 1 else 0 end as in_recovery_int,
   extract(epoch from (now() - pg_postmaster_start_time()))::int8 as postmaster_uptime_s,
-  system_identifier::text as tag_sys_id
+  system_identifier::text as tag_sys_id,
+  case
+    when pg_is_in_recovery() = false then
+      ltrim(pg_walfile_name(pg_current_wal_lsn())::char(8), '0')::int
+    else
+      (select min_recovery_end_timeline::int from pg_control_recovery())
+    end as timeline
 from pg_control_system();

--- a/pgwatch2/metrics/wal/10/metric_su.sql
+++ b/pgwatch2/metrics/wal/10/metric_su.sql
@@ -8,5 +8,11 @@ select /* pgwatch2_generated */
     end as xlog_location_b,
   case when pg_is_in_recovery() then 1 else 0 end as in_recovery_int,
   extract(epoch from (now() - coalesce((pg_stat_file('postmaster.pid', true)).modification, pg_postmaster_start_time())))::int8 as postmaster_uptime_s,
-  system_identifier::text as tag_sys_id
+  system_identifier::text as tag_sys_id,
+  case
+    when pg_is_in_recovery() = false then
+      ltrim(pg_walfile_name(pg_current_wal_lsn())::char(8), '0')::int
+    else
+      (select min_recovery_end_timeline::int from pg_control_recovery())
+    end as timeline
 from pg_control_system();


### PR DESCRIPTION
Currently only detection of restarts is possible from metrics but for
failovers one needs to turn to logs