### PR TITLE
[-] fix pgpool mode to execute only "non empty" queries 

### DIFF
--- a/pgwatch2/pgwatch2.go
+++ b/pgwatch2/pgwatch2.go
@@ -743,9 +743,8 @@ func DBExecReadByDbUniqueName(dbUnique, metricName string, stmtTimeoutOverride i
 		            data, err = DBExecRead(conn, dbUnique, sqlToExec, args...)
 		} else {
 			for _,sql := range strings.Split(sqlToExec,";") {
-			    log.Debugf("Executing Pgpool SQL: %s", sql)
 			    data, err = DBExecRead(conn, dbUnique, sql, args...)
-			    log.Debugf("Pgpool data: %s", data)
+			    log.Debugf("Query '%s' - pgpool data: %s", sql, data)
 			}
 		}
 	}

--- a/pgwatch2/pgwatch2.go
+++ b/pgwatch2/pgwatch2.go
@@ -743,8 +743,10 @@ func DBExecReadByDbUniqueName(dbUnique, metricName string, stmtTimeoutOverride i
 		            data, err = DBExecRead(conn, dbUnique, sqlToExec, args...)
 		} else {
 			for _,sql := range strings.Split(sqlToExec,";") {
+			  if len(sql) > 0 {
 			    data, err = DBExecRead(conn, dbUnique, sql, args...)
 			    log.Debugf("Query '%s' - pgpool data: %s", sql, data)
+			  }
 			}
 		}
 	}

--- a/pgwatch2/pgwatch2.go
+++ b/pgwatch2/pgwatch2.go
@@ -743,7 +743,9 @@ func DBExecReadByDbUniqueName(dbUnique, metricName string, stmtTimeoutOverride i
 		            data, err = DBExecRead(conn, dbUnique, sqlToExec, args...)
 		} else {
 			for _,sql := range strings.Split(sqlToExec,";") {
+			    log.Debugf("Executing Pgpool SQL: %s", sql)
 			    data, err = DBExecRead(conn, dbUnique, sql, args...)
+			    log.Debugf("Pgpool data: %s", data)
 			}
 		}
 	}

--- a/pgwatch2/pgwatch2.go
+++ b/pgwatch2/pgwatch2.go
@@ -745,7 +745,6 @@ func DBExecReadByDbUniqueName(dbUnique, metricName string, stmtTimeoutOverride i
 			for _,sql := range strings.Split(sqlToExec,";") {
 			  if len(sql) > 0 {
 			    data, err = DBExecRead(conn, dbUnique, sql, args...)
-			    log.Debugf("Query '%s' - pgpool data: %s", sql, data)
 			  }
 			}
 		}


### PR DESCRIPTION
Fix for 
```
WARN FetchMetricsPgpool: [pgpool_rolesdb][pgpool_stats] SHOW POOL_NODES needs to be placed before SHOW POOL_PROCESSES. ignoring SHOW POOL_PROCESSES
```
