### PR TITLE
[+] add metric and dashboard for bloated indexes and tables

### DIFF
--- a/grafana_dashboards/postgres/v8/index-overview/dashboard.json
+++ b/grafana_dashboards/postgres/v8/index-overview/dashboard.json
@@ -600,6 +600,163 @@
       "type": "table"
     },
     {
+      "columns": [],
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "id": 9,
+      "links": [],
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 3,
+        "desc": true
+      },
+      "styles": [
+        {
+          "$$hashKey": "object:134",
+          "alias": "Time",
+          "align": "auto",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "pattern": "Time",
+          "type": "hidden"
+        },
+        {
+          "$$hashKey": "object:135",
+          "alias": "",
+          "align": "auto",
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "link": true,
+          "linkTargetBlank": true,
+          "linkTooltip": "Opens 'Table details' dashboard",
+          "linkUrl": "/dashboard/db/table-details?var-dbname=${__cell_1}&var-table_full_name=${__cell}",
+          "mappingType": 1,
+          "pattern": "table_full_name",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:136",
+          "alias": "index_size",
+          "align": "auto",
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 1,
+          "mappingType": 1,
+          "pattern": "top",
+          "thresholds": [],
+          "type": "number",
+          "unit": "bytes"
+        },
+        {
+          "$$hashKey": "object:137",
+          "alias": "",
+          "align": "auto",
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 1,
+          "mappingType": 1,
+          "pattern": "idx_scans_from_last_reset",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:138",
+          "alias": "",
+          "align": "auto",
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 2,
+          "pattern": "/.*/",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "0"
+          },
+          "format": "table",
+          "group": [],
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "select \"dbname\", \"index_full_name\", \"table_full_name\", top(\"index_size_b\", 20), \"idx_scans_from_last_reset\" from (select last(\"index_size_b\") as \"index_size_b\", last(\"idx_scan\") as idx_scans_from_last_reset from index_stats where \"dbname\" =~ /^$dbname$/  AND $timeFilter group by \"table_full_name\", \"index_full_name\", \"dbname\")",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  dbname,\n  tag_data->>'index_full_name' as index_full_name,\n  tag_data->>'table_full_name' as table_full_name,\n  max((data->'leaf_fragmentation')::numeric) as fragmentation_percent\nFROM\n  index_bloat\nWHERE\n  time in (select max(time) from index_bloat where $__timeFilter(time) AND dbname in ($dbname) group by dbname)\n  AND dbname in ($dbname)\nGROUP BY\n  1, 2, 3\nORDER BY\n  4 DESC\nLIMIT\n  5\n  ",
+          "refId": "A",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "15m",
+      "title": "Top 5 Fragmentation indexes",
+      "transform": "table",
+      "type": "table-old"
+    },
+    {
       "content": "Brought to you by: <a href=\"https://www.cybertec-postgresql.com/en/\"><img src=\"https://www.cybertec-postgresql.com/wp-content/uploads/2020/11/CYBERTEC_RGB_300x80px.png\" alt=\"Cybertec – The PostgreSQL Database Company\"></a>",
       "editable": true,
       "error": false,

--- a/grafana_dashboards/postgres/v8/tables-top/dashboard.json
+++ b/grafana_dashboards/postgres/v8/tables-top/dashboard.json
@@ -1410,6 +1410,145 @@
       "type": "table"
     },
     {
+      "columns": [],
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 49
+      },
+      "id": 13,
+      "links": [],
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 2,
+        "desc": true
+      },
+      "styles": [
+        {
+          "$$hashKey": "object:149",
+          "alias": "Time",
+          "align": "auto",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "pattern": "Time",
+          "type": "hidden"
+        },
+        {
+          "$$hashKey": "object:152",
+          "alias": "",
+          "align": "auto",
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "link": true,
+          "linkTargetBlank": true,
+          "linkTooltip": "Opens 'Table details' dashboard for that table",
+          "linkUrl": "/dashboard/db/table-details?var-dbname=${__cell_0}&var-table_full_name=${__cell}&from=$__from&to=$__to",
+          "mappingType": 1,
+          "pattern": "table_full_name",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:153",
+          "alias": "",
+          "align": "auto",
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "mappingType": 1,
+          "pattern": "/^last_/",
+          "thresholds": [],
+          "type": "number",
+          "unit": "dtdurations"
+        },
+        {
+          "$$hashKey": "object:154",
+          "alias": "",
+          "align": "auto",
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 2,
+          "pattern": "/.*/",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "0"
+          },
+          "format": "table",
+          "group": [],
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "table_stats",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "rawQuery": true,
+          "rawSql": "select\n  x.*,\n  (data->'seconds_since_last_vacuum')::int8 as last_vacuum,\n  (data->'seconds_since_last_analyze')::int8 as last_analyze\nfrom (\nSELECT\n  dbname,\n  tag_data->>'full_table_name' as table_full_name,\n  max((data->'dead_tuple_percent')::numeric) as dead_tuple_percent\nFROM\n  table_bloat_approx_stattuple\nWHERE\n  $__timeFilter(time)\n  AND dbname = '$dbname'\nGROUP BY 1, 2\nORDER BY 3 DESC NULLS LAST\nLIMIT $top\n) x\njoin lateral (select data from table_stats where dbname = x.dbname and tag_data->>'table_full_name' = x.table_full_name and $__timeFilter(time) order by time desc limit 1) y on true",
+          "refId": "A",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "total_relation_size_b"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Most \"Dead tuples\" %",
+      "transform": "table",
+      "type": "table-old"
+    },
+    {
       "content": "Brought to you by: <a href=\"https://www.cybertec-postgresql.com/en/\"><img src=\"https://www.cybertec-postgresql.com/wp-content/uploads/2020/11/CYBERTEC_RGB_300x80px.png\" alt=\"Cybertec – The PostgreSQL Database Company\"></a>",
       "datasource": null,
       "gridPos": {

--- a/pgwatch2/metrics/index-bloat/10/metric.sql
+++ b/pgwatch2/metrics/index-bloat/10/metric.sql
@@ -1,0 +1,26 @@
+WITH q_locked_rels AS (
+    select relation from pg_locks where mode = 'AccessExclusiveLock' and granted
+),
+q_index_details AS (
+    select
+        sui.schemaname,
+        sui.indexrelname,
+	    sui.relname,
+        case 
+            when ((pgstatindex(sui.indexrelid)).leaf_fragmentation)::numeric = 'NaN' then 0
+            else ((pgstatindex(sui.indexrelid)).leaf_fragmentation)
+        end as leaf_fragmentation    
+    from
+        pg_stat_user_indexes sui
+        join pg_statio_user_indexes io on io.indexrelid = sui.indexrelid
+        join pg_index i on i.indexrelid = sui.indexrelid
+    where not sui.schemaname like any (array [E'pg\\_temp%', E'\\_timescaledb%'])
+    and not exists (select * from q_locked_rels where relation = sui.relid or relation = sui.indexrelid)
+)
+select  
+    (extract(epoch from now()) * 1e9)::int8 as epoch_ns, 
+    quote_ident(schemaname)||'.'||quote_ident(relname) tag_table_full_name,
+    quote_ident(indexrelname)as tag_index_full_name,
+    leaf_fragmentation
+from q_index_details 
+where leaf_fragmentation>=40;

--- a/pgwatch2/metrics/index-bloat/10/metric.sql
+++ b/pgwatch2/metrics/index-bloat/10/metric.sql
@@ -1,3 +1,4 @@
+/* NB! accessing pgstattuple_approx directly requires superuser or pg_stat_scan_tables/pg_monitor builtin roles */
 WITH q_locked_rels AS (
     select relation from pg_locks where mode = 'AccessExclusiveLock' and granted
 ),
@@ -12,8 +13,6 @@ q_index_details AS (
         end as leaf_fragmentation    
     from
         pg_stat_user_indexes sui
-        join pg_statio_user_indexes io on io.indexrelid = sui.indexrelid
-        join pg_index i on i.indexrelid = sui.indexrelid
     where not sui.schemaname like any (array [E'pg\\_temp%', E'\\_timescaledb%'])
     and not exists (select * from q_locked_rels where relation = sui.relid or relation = sui.indexrelid)
 )


### PR DESCRIPTION
Since there is no panel in TablesTop that shows which table is bloated, it was added based on the existing table_bloat_approx_stattuple metric.

Following the same line and based on the experience of some cases where I have seen indexes bloats, a metric based on the pgstattuple extension with the help pgstatindex (leaf_fragmentation) function is proposed.

All this was tested in PostgreSQL 12.