### PR TITLE
[*] remove trailing space for SQL commands for non-Postgres DB types

### DIFF
--- a/pgwatch2/pgwatch2.go
+++ b/pgwatch2/pgwatch2.go
@@ -748,6 +748,7 @@ func DBExecReadByDbUniqueName(dbUnique, metricName string, stmtTimeoutOverride i
 			data, err = DBExecRead(conn, dbUnique, sqlToExec, args...)
 		} else {
 			for _, sql := range strings.Split(sqlToExec, ";") {
+				sql = strings.TrimSpace(sql)
 				if len(sql) > 0 {
 					data, err = DBExecRead(conn, dbUnique, sql, args...)
 				}


### PR DESCRIPTION
This patch fix a bug with pgbouncer, which return an error with a query containing only a linefeed.