### PR TITLE
Add a timescaledb based docker image

### DIFF
--- a/build-all-images-latest.sh
+++ b/build-all-images-latest.sh
@@ -32,6 +32,14 @@ else
   echo "ok"
 fi
 
+echo "building build-docker-timescale (log: build-docker-timescale.log)"
+./build-docker-timescale.sh &> build-docker-timescale.log
+if [ $? -ne 0 ]; then
+  echo "failed. see log for details"
+else
+  echo "ok"
+fi
+
 echo "building build-docker-db-bootstrapper (log: build-docker-db-bootstrapper.log)"
 ./build-docker-db-bootstrapper.sh &> build-docker-db-bootstrapper.log
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
@kmoppel-cognite  Wanted to ask you to adjust some shell scripts before merge :-) 
 
I think we should update `docker\test\smoke_test_docker_image.sh` and `docker\test\smoke_test_all_latest_images.sh` since they are used in testing process.

Do you think we should add timescale based docker image to the list of auto built tags which controlled by GHA workflow in `.github\workflows\release.yml`?

