### PR TITLE
[-] fix timeline ID conversion in `wal` metric from hexadecimal to decimal

### DIFF
--- a/pgwatch2/metrics/wal/10/metric.sql
+++ b/pgwatch2/metrics/wal/10/metric.sql
@@ -11,7 +11,7 @@ select /* pgwatch2_generated */
   system_identifier::text as tag_sys_id,
   case
     when pg_is_in_recovery() = false then
-      ltrim(pg_walfile_name(pg_current_wal_lsn())::char(8), '0')::int
+      ('x'||substr(pg_walfile_name(pg_current_wal_lsn()), 1, 8))::bit(32)::int
     else
       (select min_recovery_end_timeline::int from pg_control_recovery())
     end as timeline

--- a/pgwatch2/metrics/wal/10/metric_su.sql
+++ b/pgwatch2/metrics/wal/10/metric_su.sql
@@ -11,7 +11,7 @@ select /* pgwatch2_generated */
   system_identifier::text as tag_sys_id,
   case
     when pg_is_in_recovery() = false then
-      ltrim(pg_walfile_name(pg_current_wal_lsn())::char(8), '0')::int
+      ('x'||substr(pg_walfile_name(pg_current_wal_lsn()), 1, 8))::bit(32)::int
     else
       (select min_recovery_end_timeline::int from pg_control_recovery())
     end as timeline

--- a/pgwatch2/sql/config_store/metric_definitions.sql
+++ b/pgwatch2/sql/config_store/metric_definitions.sql
@@ -2720,7 +2720,7 @@ select
   system_identifier::text as tag_sys_id,
   case
     when pg_is_in_recovery() = false then
-      ltrim(pg_walfile_name(pg_current_wal_lsn())::char(8), '0')::int
+      ('x'||substr(pg_walfile_name(pg_current_wal_lsn()), 1, 8))::bit(32)::int
     else
       (select min_recovery_end_timeline::int from pg_control_recovery())
     end as timeline
@@ -2740,7 +2740,7 @@ select
   system_identifier::text as tag_sys_id,
   case
     when pg_is_in_recovery() = false then
-      ltrim(pg_walfile_name(pg_current_wal_lsn())::char(8), '0')::int
+      ('x'||substr(pg_walfile_name(pg_current_wal_lsn()), 1, 8))::bit(32)::int
     else
       (select min_recovery_end_timeline::int from pg_control_recovery())
     end as timeline


### PR DESCRIPTION
As timelineid is hexadecimal in pg_walfile_name(), this fix correctly convert it to int. 

Without this fix, queries fail when tlid reaches to A, and could give wrong results when decimals symbols is used
