### PR TITLE
[*] fix `key_file` to `key` on `host_config`

### DIFF
--- a/pgwatch2/config/instances.yaml
+++ b/pgwatch2/config/instances.yaml
@@ -42,7 +42,7 @@
     password:
     ca_file:
     cert_file:
-    cert_key:
+    key_file:
     logs_glob_path: "/tmp/*.csv"
     logs_match_regex: ^(?P<log_time>.*?),"?(?P<user_name>.*?)"?,"?(?P<database_name>.*?)"?,(?P<process_id>\d+),"?(?P<connection_from>.*?)"?,(?P<session_id>.*?),(?P<session_line_num>\d+),"?(?P<command_tag>.*?)"?,(?P<session_start_time>.*?),(?P<virtual_transaction_id>.*?),(?P<transaction_id>.*?),(?P<error_severity>\w+),
 #    logs_match_regex: '^(?P<log_time>.*) \[(?P<process_id>\d+)\] (?P<user_name>.*)@(?P<database_name>.*?) (?P<error_severity>.*?): ' # a sample regex (Debian / Ubuntu default) if not using CSVLOG


### PR DESCRIPTION
Change cert_key to correct parameter.

Reopen #495

Minor change in instances example file for YAML based setup.

Configuration shows to require 'key_file' named parameter. 
https://github.com/cybertec-postgresql/pgwatch2/blob/master/pgwatch2/pgwatch2.go#L91 

