### PR TITLE
Add "prerequisite extensions" support for metric definitions

### DIFF
--- a/pgwatch2/metrics/stat_statements/metric_attrs.yaml
+++ b/pgwatch2/metrics/stat_statements/metric_attrs.yaml
@@ -1,4 +1,3 @@
 ---
-metric_storage_name: stat_statements
 prerequisite_extensions:
   - pg_stat_statements

--- a/pgwatch2/metrics/stat_statements_calls/metric_attrs.yaml
+++ b/pgwatch2/metrics/stat_statements_calls/metric_attrs.yaml
@@ -1,4 +1,3 @@
 ---
-metric_storage_name: stat_statements
 prerequisite_extensions:
   - pg_stat_statements

--- a/pgwatch2/sql/config_store/metric_definitions.sql
+++ b/pgwatch2/sql/config_store/metric_definitions.sql
@@ -8072,9 +8072,19 @@ do update set ma_metric_attrs = pgwatch2.metric_attribute.ma_metric_attrs || '{"
 
 -- dynamic re-routing of metric names
 insert into pgwatch2.metric_attribute (ma_metric_name, ma_metric_attrs)
-select 'stat_statements_no_query_text', '{"metric_storage_name": "stat_statements"}'
+select 'stat_statements_no_query_text', '{"metric_storage_name": "stat_statements", "prerequisite_extensions": ["pg_stat_statements"]}'
 on conflict (ma_metric_name)
-do update set ma_metric_attrs = pgwatch2.metric_attribute.ma_metric_attrs || '{"metric_storage_name": "stat_statements"}', ma_last_modified_on = now();
+do update set ma_metric_attrs = pgwatch2.metric_attribute.ma_metric_attrs || '{"metric_storage_name": "stat_statements", "prerequisite_extensions": ["pg_stat_statements"]}', ma_last_modified_on = now();
+
+insert into pgwatch2.metric_attribute (ma_metric_name, ma_metric_attrs)
+select 'stat_statements', '{"prerequisite_extensions": ["pg_stat_statements"]}'
+on conflict (ma_metric_name)
+do update set ma_metric_attrs = pgwatch2.metric_attribute.ma_metric_attrs || '{"prerequisite_extensions": ["pg_stat_statements"]}', ma_last_modified_on = now();
+
+insert into pgwatch2.metric_attribute (ma_metric_name, ma_metric_attrs)
+select 'stat_statements_calls', '{"prerequisite_extensions": ["pg_stat_statements"]}'
+on conflict (ma_metric_name)
+do update set ma_metric_attrs = pgwatch2.metric_attribute.ma_metric_attrs || '{"prerequisite_extensions": ["pg_stat_statements"]}', ma_last_modified_on = now();
 
 insert into pgwatch2.metric_attribute (ma_metric_name, ma_metric_attrs)
 select 'db_stats_aurora', '{"metric_storage_name": "db_stats"}'


### PR DESCRIPTION
To reduce regular errors in server logs of monitored DBs. That is - we don't even try to query the DB if we know that some prerequisite is missing and it would error anyways. In the pgwatch2 logs the errors got reduced already to 1x per 10min, but increase that to 1h also for this case.

For now only for pg_stat_statements as that's by far the most common one in use.