### PR TITLE
Allow pgpass lookup for web

### DIFF
--- a/webpy/datadb.py
+++ b/webpy/datadb.py
@@ -19,8 +19,12 @@ def setConnectionStringForMetrics(conn_string):
 
 def setConnectionString(host, port, dbname, username, password, require_ssl=False, connect_timeout=10):
     global connection_string
-    connection_string = 'host={} port={} dbname={} user={} password={} connect_timeout={} {}'.format(
-        host, port, dbname, username, password, connect_timeout, '' if not require_ssl else 'sslmode=require')
+    if password == '': # In case of empty password .pgpass lookup will be used
+        connection_string = 'host={} port={} dbname={} user={} connect_timeout={} {}'.format(
+            host, port, dbname, username, connect_timeout, '' if not require_ssl else 'sslmode=require')
+    else:
+        connection_string = 'host={} port={} dbname={} user={} password={} connect_timeout={} {}'.format(
+            host, port, dbname, username, password, connect_timeout, '' if not require_ssl else 'sslmode=require')
 
 
 def getConnection(conn_str=None, autocommit=True):

--- a/webpy/web.py
+++ b/webpy/web.py
@@ -365,7 +365,7 @@ if __name__ == '__main__':
     parser.add_argument('-U', '--user', help='Pgwatch2 Config DB username',
                         default=(os.getenv('PW2_PGUSER') or 'pgwatch2'))
     parser.add_argument('--password', help='Pgwatch2 Config DB password',
-                        default=(os.getenv('PW2_PGPASSWORD') or 'pgwatch2admin'))
+                        default=(os.getenv('PW2_PGPASSWORD') or ''))
     parser.add_argument('--pg-require-ssl', help='Pgwatch2 Config DB SSL connection only', action='store_true',
                         default=(str_to_bool_or_fail(os.getenv('PW2_PGSSL')) or False))
 


### PR DESCRIPTION
Currently it does not support pgpass for web config db. This will fix it. If password is provided, then it will be used instead.