### PR TITLE
[+] update README.md to show support of PG15

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # pgwatch2
 
-Flexible self-contained PostgreSQL metrics monitoring/dashboarding solution. Supports monitoring PG versions 9.0 to 14 out of the box.
+Flexible self-contained PostgreSQL metrics monitoring/dashboarding solution. Supports monitoring PG versions 9.0 to 15 out of the box.
 
 # Demo
 


### PR DESCRIPTION
As of v1.10.0 pgwatch2 supports Postgres version 15. Readme should reflect it. 