### PR TITLE
Additional useful replication metrics

### DIFF
--- a/pgwatch2/sql/config_store/metric_definitions.sql
+++ b/pgwatch2/sql/config_store/metric_definitions.sql
@@ -5084,7 +5084,48 @@ $sql$
 select
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   coalesce(sum(calls), 0)::int8 as calls,
-  coalesce(round(sum(total_time)::numeric, 3), 0)::float8 as total_time
+  coalesce(round(sum(total_time)::numeric, 3), 0)::float8 as total_time,
+  coalesce(sum(shared_blks_hit), 0)::int8 as shared_blks_hit,
+  coalesce(sum(shared_blks_read), 0)::int8 as shared_blks_read,
+  coalesce(sum(shared_blks_dirtied), 0)::int8 as shared_blks_dirtied,
+  coalesce(sum(shared_blks_written), 0)::int8 as shared_blks_written,
+  coalesce(sum(local_blks_hit), 0)::int8 as local_blks_hit,
+  coalesce(sum(local_blks_read), 0)::int8 as local_blks_read,
+  coalesce(sum(local_blks_dirtied), 0)::int8 as local_blks_dirtied,
+  coalesce(sum(local_blks_written), 0)::int8 as local_blks_written,
+  coalesce(sum(temp_blks_read), 0)::int8 as temp_blks_read,
+  coalesce(sum(temp_blks_written), 0)::int8 as temp_blks_written,
+  coalesce(sum(blk_read_time), 0)::int8 as blk_read_time,
+  coalesce(sum(blk_write_time), 0)::int8 as blk_write_time
+from
+  pg_stat_statements
+where
+  dbid = (select oid from pg_database where datname = current_database())
+;
+$sql$
+);
+
+insert into pgwatch2.metric(m_name, m_pg_version_from, m_sql)
+values (
+'stat_statements_calls',
+9.5,
+$sql$
+select
+  (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+  coalesce(sum(calls), 0)::int8 as calls,
+  coalesce(round(sum(total_time)::numeric, 3), 0)::float8 as total_time,
+  coalesce(sum(shared_blks_hit), 0)::int8 as shared_blks_hit,
+  coalesce(sum(shared_blks_read), 0)::int8 as shared_blks_read,
+  coalesce(sum(shared_blks_dirtied), 0)::int8 as shared_blks_dirtied,
+  coalesce(sum(shared_blks_written), 0)::int8 as shared_blks_written,
+  coalesce(sum(local_blks_hit), 0)::int8 as local_blks_hit,
+  coalesce(sum(local_blks_read), 0)::int8 as local_blks_read,
+  coalesce(sum(local_blks_dirtied), 0)::int8 as local_blks_dirtied,
+  coalesce(sum(local_blks_written), 0)::int8 as local_blks_written,
+  coalesce(sum(temp_blks_read), 0)::int8 as temp_blks_read,
+  coalesce(sum(temp_blks_written), 0)::int8 as temp_blks_written,
+  coalesce(sum(blk_read_time), 0)::int8 as blk_read_time,
+  coalesce(sum(blk_write_time), 0)::int8 as blk_write_time
 from
   pg_stat_statements
 where
@@ -5102,7 +5143,19 @@ select
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   coalesce(sum(calls), 0)::int8 as calls,
   coalesce(round(sum(total_exec_time)::numeric, 3), 0)::float8 as total_time,
-  round(sum(total_plan_time)::numeric, 3)::double precision as total_plan_time
+  round(sum(total_plan_time)::numeric, 3)::double precision as total_plan_time,
+  coalesce(sum(shared_blks_hit), 0)::int8 as shared_blks_hit,
+  coalesce(sum(shared_blks_read), 0)::int8 as shared_blks_read,
+  coalesce(sum(shared_blks_dirtied), 0)::int8 as shared_blks_dirtied,
+  coalesce(sum(shared_blks_written), 0)::int8 as shared_blks_written,
+  coalesce(sum(local_blks_hit), 0)::int8 as local_blks_hit,
+  coalesce(sum(local_blks_read), 0)::int8 as local_blks_read,
+  coalesce(sum(local_blks_dirtied), 0)::int8 as local_blks_dirtied,
+  coalesce(sum(local_blks_written), 0)::int8 as local_blks_written,
+  coalesce(sum(temp_blks_read), 0)::int8 as temp_blks_read,
+  coalesce(sum(temp_blks_written), 0)::int8 as temp_blks_written,
+  coalesce(sum(blk_read_time), 0)::int8 as blk_read_time,
+  coalesce(sum(blk_write_time), 0)::int8 as blk_write_time
 from
   pg_stat_statements
 where

--- a/pgwatch2/sql/config_store/metric_definitions.sql
+++ b/pgwatch2/sql/config_store/metric_definitions.sql
@@ -1834,6 +1834,7 @@ SELECT
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   application_name as tag_application_name,
   concat(coalesce(client_addr::text, client_hostname), '_', client_port::text) as tag_client_info,
+  coalesce(pg_wal_lsn_diff(case when pg_is_in_recovery() then pg_last_wal_receive_lsn() else pg_current_wal_lsn() end, sent_lsn)::int8, 0) as sent_lag_b,
   coalesce(pg_wal_lsn_diff(case when pg_is_in_recovery() then pg_last_wal_receive_lsn() else pg_current_wal_lsn() end, write_lsn)::int8, 0) as write_lag_b,
   coalesce(pg_wal_lsn_diff(case when pg_is_in_recovery() then pg_last_wal_receive_lsn() else pg_current_wal_lsn() end, flush_lsn)::int8, 0) as flush_lag_b,
   coalesce(pg_wal_lsn_diff(case when pg_is_in_recovery() then pg_last_wal_receive_lsn() else pg_current_wal_lsn() end, replay_lsn)::int8, 0) as replay_lag_b,
@@ -6929,6 +6930,7 @@ select
   active,
   case when active then 0 else 1 end as non_active_int,
   pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)::int8 as restart_lsn_lag_b,
+  pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)::int8 as confirmed_flush_lsn_lag_b,
   greatest(age(xmin), age(catalog_xmin))::int8 as xmin_age_tx
 from
   pg_replication_slots;

--- a/pgwatch2/sql/config_store/metric_definitions.sql
+++ b/pgwatch2/sql/config_store/metric_definitions.sql
@@ -1834,7 +1834,6 @@ SELECT
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   application_name as tag_application_name,
   concat(coalesce(client_addr::text, client_hostname), '_', client_port::text) as tag_client_info,
-  coalesce(pg_wal_lsn_diff(case when pg_is_in_recovery() then pg_last_wal_receive_lsn() else pg_current_wal_lsn() end, sent_lsn)::int8, 0) as sent_lag_b,
   coalesce(pg_wal_lsn_diff(case when pg_is_in_recovery() then pg_last_wal_receive_lsn() else pg_current_wal_lsn() end, write_lsn)::int8, 0) as write_lag_b,
   coalesce(pg_wal_lsn_diff(case when pg_is_in_recovery() then pg_last_wal_receive_lsn() else pg_current_wal_lsn() end, flush_lsn)::int8, 0) as flush_lag_b,
   coalesce(pg_wal_lsn_diff(case when pg_is_in_recovery() then pg_last_wal_receive_lsn() else pg_current_wal_lsn() end, replay_lsn)::int8, 0) as replay_lag_b,
@@ -6982,8 +6981,7 @@ select
   coalesce(plugin, 'physical')::text as plugin,
   active,
   case when active then 0 else 1 end as non_active_int,
-  pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)::int8 as restart_lsn_lag_b,
-  pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)::int8 as confirmed_flush_lsn_lag_b,
+  pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)::int8 as restart_lsn_lag_b
   greatest(age(xmin), age(catalog_xmin))::int8 as xmin_age_tx
 from
   pg_replication_slots;


### PR DESCRIPTION
pg_stat_replication.sent_lag and pg_replication_slots.confirmed_flush_lsn

`sent_lag` measures the amount of WAL data that is pending replication to a specific standby and helps DBA and operators to identify potential performance bottlenecks and optimize the replication process to minimize lag.

The `confirmed_flush_lsn` of a replication slot indicates the last LSN that has been successfully written to the WAL on the primary server and subsequently replicated to the associated standby server. It can be used as a reference point to ensure replication consistency.
