### PR TITLE
[+] add `sent_lag` and `confirmed_flush_lsn_lag` fields to replication metrics

### DIFF
--- a/pgwatch2/metrics/replication/10/metric.sql
+++ b/pgwatch2/metrics/replication/10/metric.sql
@@ -2,6 +2,7 @@ select /* pgwatch2_generated */
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   application_name as tag_application_name,
   concat(coalesce(client_addr::text, client_hostname), '_', client_port::text) as tag_client_info,
+  coalesce(pg_wal_lsn_diff(case when pg_is_in_recovery() then pg_last_wal_receive_lsn() else pg_current_wal_lsn() end, sent_lsn)::int8, 0) as sent_lag_b,
   coalesce(pg_wal_lsn_diff(case when pg_is_in_recovery() then pg_last_wal_receive_lsn() else pg_current_wal_lsn() end, write_lsn)::int8, 0) as write_lag_b,
   coalesce(pg_wal_lsn_diff(case when pg_is_in_recovery() then pg_last_wal_receive_lsn() else pg_current_wal_lsn() end, flush_lsn)::int8, 0) as flush_lag_b,
   coalesce(pg_wal_lsn_diff(case when pg_is_in_recovery() then pg_last_wal_receive_lsn() else pg_current_wal_lsn() end, replay_lsn)::int8, 0) as replay_lag_b,

--- a/pgwatch2/metrics/replication_slots/10/metric_master.sql
+++ b/pgwatch2/metrics/replication_slots/10/metric_master.sql
@@ -5,6 +5,7 @@ select /* pgwatch2_generated */
   active,
   case when active then 0 else 1 end as non_active_int,
   pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)::int8 as restart_lsn_lag_b,
+  pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)::int8 as confirmed_flush_lsn_lag_b,
   greatest(age(xmin), age(catalog_xmin))::int8 as xmin_age_tx
 from
   pg_replication_slots;

--- a/pgwatch2/sql/config_store/metric_definitions.sql
+++ b/pgwatch2/sql/config_store/metric_definitions.sql
@@ -1834,6 +1834,7 @@ SELECT
   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
   application_name as tag_application_name,
   concat(coalesce(client_addr::text, client_hostname), '_', client_port::text) as tag_client_info,
+  coalesce(pg_wal_lsn_diff(case when pg_is_in_recovery() then pg_last_wal_receive_lsn() else pg_current_wal_lsn() end, sent_lsn)::int8, 0) as sent_lag_b,
   coalesce(pg_wal_lsn_diff(case when pg_is_in_recovery() then pg_last_wal_receive_lsn() else pg_current_wal_lsn() end, write_lsn)::int8, 0) as write_lag_b,
   coalesce(pg_wal_lsn_diff(case when pg_is_in_recovery() then pg_last_wal_receive_lsn() else pg_current_wal_lsn() end, flush_lsn)::int8, 0) as flush_lag_b,
   coalesce(pg_wal_lsn_diff(case when pg_is_in_recovery() then pg_last_wal_receive_lsn() else pg_current_wal_lsn() end, replay_lsn)::int8, 0) as replay_lag_b,
@@ -6929,6 +6930,7 @@ select
   active,
   case when active then 0 else 1 end as non_active_int,
   pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)::int8 as restart_lsn_lag_b,
+  pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)::int8 as confirmed_flush_lsn_lag_b,
   greatest(age(xmin), age(catalog_xmin))::int8 as xmin_age_tx
 from
   pg_replication_slots;


### PR DESCRIPTION
pg_stat_replication.sent_lag and pg_replication_slots.confirmed_flush_lsn

`sent_lag` measures the amount of WAL data that is pending replication to a specific standby and helps DBA and operators to identify potential performance bottlenecks and optimize the replication process to minimize lag.

The `confirmed_flush_lsn` of a replication slot indicates the last LSN that has been successfully written to the WAL on the primary server and subsequently replicated to the associated standby server. It can be used as a reference point to ensure replication consistency.
