### PR TITLE
[-] fix warning about `yaml.load()` is deprecated, closes #738

### DIFF
--- a/pgwatch2/metrics/00_helpers/rollout_helper.py
+++ b/pgwatch2/metrics/00_helpers/rollout_helper.py
@@ -200,7 +200,7 @@ def get_monitored_dbs_from_yaml_config():   # active entries ("is_enabled": true
                 with open(os.path.join(root, f), 'r') as fp:
                     config = fp.read()
                 try:
-                    monitored_dbs = yaml.load(config)
+                    monitored_dbs = yaml.full_load(config)
                 except:
                     logging.error("skipping config file %s as could not parse YAML")
                     continue


### PR DESCRIPTION
This is a fix for deprecated use of the yaml.load function. Apparently yaml.load carries some security concerns with how it de-serializes data from the yaml file, (arbitrary python code could be executed if embedded in the yaml file). As a result the library maintainers want users to be more explicit about what loader they are using to load the yaml.
 
The current usage of yaml.load in pgwatch2 is equivalent to the yaml.full_load function used in this PR. A safer choice might be the yaml.safe_load function but I would be concerned about regression issues.

Let me know if this change makes sense to you or if you want to drop down to using the safe_load function. Also let me know if you would like me to include some unit tests to prevent regressions/deprecation issues going forward.