### PR TITLE
[+] allow setting arbitrary configs to the webui pod

### DIFF
--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -207,6 +207,11 @@ spec:
         - name: {{ .Chart.Name }}-webui
           image: "{{ .Values.webui.image.repository }}:{{ .Values.webui.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.webui.image.pullPolicy }}
+          {{- if .Values.webui.command }}
+          command: [{{- range $index, $cmd := .Values.webui.command }}
+            "{{ $cmd }}"{{- if lt $index (sub (len $.Values.webui.command) 1) }},{{ end }}
+          {{- end }}]
+          {{- end }}
           env:
           - name: PW2_PGHOST
             value: {{ .Values.postgresql.host | default (printf "%s-postgresql" (include "pgwatch2.fullname" .)) }}

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -249,6 +249,9 @@ spec:
             value: {{ .Values.webui.user | default "pgwatch2" }}
           - name: PW2_WEBPASSWORD
             value: {{ .Values.webui.password | default "pgwatch2" }}
+          envFrom:
+          - configMapRef:
+              name: {{ include "pgwatch2.fullname" . }}-env
           {{- with .Values.daemon.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/webpy/templates/stats-summary.html
+++ b/webpy/templates/stats-summary.html
@@ -173,7 +173,7 @@
                 <tbody>
                   {% for d in data %}
                   <tr>
-                    <td><a href="{{grafana_baseurl}}/dashboard/db/single-query-details?var-queryid={{d['queryid']}}&var-dbname={{dbname}}" target="_blank">{{d['queryid']}}</td>
+                    <td><a href="{{grafana_baseurl}}/d/single-query-details/single-query-details?var-queryid={{d['queryid']}}&var-dbname={{dbname}}" target="_blank">{{d['queryid']}}</td>
                     <td>{{d['query']}}</td>
                     <td>{{d['total_time']}}</td>
                     <td>{{d['mean_time']}}</td>


### PR DESCRIPTION
heya, 

hopefully uncontentious. 

i am running pgwatch as a helm chart, so different daemon and webui pods. 

previously there didn't seem to be any way to add additional env vars to the webui pod. 

obvs different ways to solve this problem, this seems easiest / best to me. 

not sure if sharing env vars between the daemon and webui pods is going to cause issues? 