### PR TITLE
[-] fix replication slots metrics for replica instances

### DIFF
--- a/pgwatch2/metrics/replication_slots/10/metric_master.sql
+++ b/pgwatch2/metrics/replication_slots/10/metric_master.sql
@@ -4,8 +4,10 @@ select /* pgwatch2_generated */
   coalesce(plugin, 'physical')::text as tag_plugin,
   active,
   case when active then 0 else 1 end as non_active_int,
-  pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)::int8 as restart_lsn_lag_b,
-  pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)::int8 as confirmed_flush_lsn_lag_b,
-  greatest(age(xmin), age(catalog_xmin))::int8 as xmin_age_tx
+  case when pg_is_in_recovery() = FALSE then pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)::int8
+  else pg_wal_lsn_diff(pg_last_wal_replay_lsn(), restart_lsn)::int8 end as restart_lsn_lag_b,
+  case when pg_is_in_recovery() = FALSE then pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)::int8
+  else pg_wal_lsn_diff(pg_last_wal_replay_lsn(), confirmed_flush_lsn)::int8 end as confirmed_flush_lsn_lag_b,
+  greatest(age(xmin),age(catalog_xmin))::int8 as xmin_age_tx
 from
   pg_replication_slots;

--- a/pgwatch2/metrics/replication_slots/10/metric_master.sql
+++ b/pgwatch2/metrics/replication_slots/10/metric_master.sql
@@ -4,10 +4,10 @@ select /* pgwatch2_generated */
   coalesce(plugin, 'physical')::text as tag_plugin,
   active,
   case when active then 0 else 1 end as non_active_int,
-  case when pg_is_in_recovery() = FALSE then pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)::int8
+  case when not pg_is_in_recovery() then pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)::int8
   else pg_wal_lsn_diff(pg_last_wal_replay_lsn(), restart_lsn)::int8 end as restart_lsn_lag_b,
-  case when pg_is_in_recovery() = FALSE then pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)::int8
+  case when not pg_is_in_recovery() then pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)::int8
   else pg_wal_lsn_diff(pg_last_wal_replay_lsn(), confirmed_flush_lsn)::int8 end as confirmed_flush_lsn_lag_b,
-  greatest(age(xmin),age(catalog_xmin))::int8 as xmin_age_tx
+  greatest(age(xmin), age(catalog_xmin))::int8 as xmin_age_tx
 from
   pg_replication_slots;

--- a/pgwatch2/sql/config_store/metric_definitions.sql
+++ b/pgwatch2/sql/config_store/metric_definitions.sql
@@ -6929,8 +6929,10 @@ select
   coalesce(plugin, 'physical')::text as plugin,
   active,
   case when active then 0 else 1 end as non_active_int,
-  pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)::int8 as restart_lsn_lag_b,
-  pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)::int8 as confirmed_flush_lsn_lag_b,
+  case when pg_is_in_recovery() = FALSE then pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)::int8
+  else pg_wal_lsn_diff(pg_last_wal_replay_lsn(), restart_lsn)::int8 end as restart_lsn_lag_b,
+  case when pg_is_in_recovery() = FALSE then pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)::int8
+  else pg_wal_lsn_diff(pg_last_wal_replay_lsn(), confirmed_flush_lsn)::int8 end as confirmed_flush_lsn_lag_b,
   greatest(age(xmin), age(catalog_xmin))::int8 as xmin_age_tx
 from
   pg_replication_slots;

--- a/pgwatch2/sql/config_store/metric_definitions.sql
+++ b/pgwatch2/sql/config_store/metric_definitions.sql
@@ -6929,9 +6929,9 @@ select
   coalesce(plugin, 'physical')::text as plugin,
   active,
   case when active then 0 else 1 end as non_active_int,
-  case when pg_is_in_recovery() = FALSE then pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)::int8
+  case when not pg_is_in_recovery() then pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)::int8
   else pg_wal_lsn_diff(pg_last_wal_replay_lsn(), restart_lsn)::int8 end as restart_lsn_lag_b,
-  case when pg_is_in_recovery() = FALSE then pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)::int8
+  case when not pg_is_in_recovery() then pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)::int8
   else pg_wal_lsn_diff(pg_last_wal_replay_lsn(), confirmed_flush_lsn)::int8 end as confirmed_flush_lsn_lag_b,
   greatest(age(xmin), age(catalog_xmin))::int8 as xmin_age_tx
 from


### PR DESCRIPTION
This PR solve the following issue :

```
ERROR:  recovery is in progress
HINT:  WAL control functions cannot be executed during recovery.
```
Since  `pg_current_wal_lsn()` execution is not allowed on replica instances `pg_last_wal_replay_lsn()` is used.