### PR TITLE
v17 preliminary support

### DIFF
--- a/pgwatch2/metrics/bgwriter/17/metric.sql
+++ b/pgwatch2/metrics/bgwriter/17/metric.sql
@@ -1,0 +1,8 @@
+select /* pgwatch2_generated */
+   (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+   buffers_clean,
+   maxwritten_clean,
+   buffers_alloc,
+   (extract(epoch from now() - stats_reset))::int as last_reset_s
+ from
+   pg_stat_bgwriter;

--- a/pgwatch2/metrics/checkpointer/17/metric.sql
+++ b/pgwatch2/metrics/checkpointer/17/metric.sql
@@ -1,0 +1,13 @@
+select /* pgwatch2_generated */
+  (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+  num_timed,
+  num_requested,
+  restartpoints_timed,
+  restartpoints_req,
+  restartpoints_done,
+  write_time,
+  sync_time,
+  buffers_written,
+  (extract(epoch from now() - stats_reset))::int as last_reset_s
+from
+  pg_stat_checkpointer;

--- a/pgwatch2/metrics/preset-configs.yaml
+++ b/pgwatch2/metrics/preset-configs.yaml
@@ -13,6 +13,7 @@
     archiver: 60
     backends: 60
     bgwriter: 60
+    checkpointer: 60
     change_events: 300
     cpu_load: 60
     db_stats: 60
@@ -69,6 +70,7 @@
     archiver: 60
     backends: 60
     bgwriter: 60
+    checkpointer: 60
     change_events: 300
     cpu_load: 60
     db_stats: 60
@@ -108,6 +110,7 @@
     archiver: 60
     backends: 60
     bgwriter: 60
+    checkpointer: 60
     change_events: 300
     cpu_load: 60
     db_stats: 60
@@ -143,6 +146,7 @@
   metrics:
     archiver: 60
     bgwriter: 60
+    checkpointer: 60
     change_events: 300
     db_stats: 60
     db_size: 300
@@ -182,6 +186,7 @@
   metrics:
     backends: 30
     bgwriter: 60
+    checkpointer: 60
     db_stats: 30
     db_size: 300
     locks_mode: 30
@@ -201,6 +206,7 @@
     archiver: 60
     backends: 60
     bgwriter: 60
+    checkpointer: 60
     change_events: 300
     db_stats: 60
     db_size: 300
@@ -228,6 +234,7 @@
     archiver: 60
     backends: 60
     bgwriter: 60
+    checkpointer: 60
     change_events: 300
     db_stats_aurora: 60
     db_size: 300
@@ -251,6 +258,7 @@
     archiver: 60
     backends: 60
     bgwriter: 60
+    checkpointer: 60
     change_events: 300
     db_stats: 60
     db_size: 300
@@ -279,6 +287,7 @@
     archiver: 60
     backends: 60
     bgwriter: 60
+    checkpointer: 60
     change_events: 300
     db_stats: 60
     db_size: 300
@@ -310,6 +319,7 @@
     archiver: 60
     backends: 60
     bgwriter: 60
+    checkpointer: 60
     db_stats: 60
     settings: 7200
     stat_ssl: 60
@@ -332,6 +342,7 @@
     archiver: 60
     backends: 60
     bgwriter: 60
+    checkpointer: 60
     change_events: 300
     db_stats: 60
     db_size: 300
@@ -361,6 +372,7 @@
     archiver: 60
     backends: 60
     bgwriter: 60
+    checkpointer: 60
     cpu_load: 60
     db_stats: 60
     settings: 7200

--- a/pgwatch2/metrics/stat_statements/17/metric.sql
+++ b/pgwatch2/metrics/stat_statements/17/metric.sql
@@ -1,0 +1,145 @@
+WITH /* pgwatch2_generated */ q_data AS (
+    SELECT
+        queryid::text AS tag_queryid,
+        /*
+         NB! if security conscious about exposing query texts replace the below expression with a dash ('-') OR
+         use the stat_statements_no_query_text metric instead, created specifically for this use case.
+         */
+        array_to_string(array_agg(DISTINCT quote_ident(pg_get_userbyid(userid))), ',') AS users,
+        sum(s.calls)::int8 AS calls,
+        round(sum(s.total_exec_time)::numeric, 3)::double precision AS total_time,
+        sum(shared_blks_hit)::int8 AS shared_blks_hit,
+        sum(shared_blks_read)::int8 AS shared_blks_read,
+        sum(shared_blks_written)::int8 AS shared_blks_written,
+        sum(shared_blks_dirtied)::int8 AS shared_blks_dirtied,
+        sum(temp_blks_read)::int8 AS temp_blks_read,
+        sum(temp_blks_written)::int8 AS temp_blks_written,
+        round((sum(shared_blk_read_time) + sum(local_blk_read_time))::numeric, 3)::double precision AS blk_read_time,
+        round((sum(shared_blk_write_time) + sum(local_blk_write_time))::numeric, 3)::double precision AS blk_write_time,
+        round(sum(temp_blk_read_time)::numeric, 3)::double precision AS temp_blk_read_time,
+        round(sum(temp_blk_write_time)::numeric, 3)::double precision AS temp_blk_write_time,
+        sum(wal_fpi)::int8 AS wal_fpi,
+        sum(wal_bytes)::int8 AS wal_bytes,
+        round(sum(s.total_plan_time)::numeric, 3)::double precision AS total_plan_time,
+        max(query::varchar(8000)) AS query
+    FROM
+        get_stat_statements() s
+    WHERE
+        calls > 5
+        AND total_exec_time > 5
+        AND dbid = (
+            SELECT
+                oid
+            FROM
+                pg_database
+            WHERE
+                datname = current_database())
+            AND NOT upper(s.query::varchar(50))
+            LIKE ANY (ARRAY['DEALLOCATE%',
+                'SET %',
+                'RESET %',
+                'BEGIN%',
+                'BEGIN;',
+                'COMMIT%',
+                'END%',
+                'ROLLBACK%',
+                'SHOW%'])
+        GROUP BY
+            queryid
+)
+SELECT
+    (EXTRACT(epoch FROM now()) * 1e9)::int8 AS epoch_ns,
+    b.tag_queryid,
+    b.users,
+    b.calls,
+    b.total_time,
+    b.shared_blks_hit,
+    b.shared_blks_read,
+    b.shared_blks_written,
+    b.shared_blks_dirtied,
+    b.temp_blks_read,
+    b.temp_blks_written,
+    b.blk_read_time,
+    b.blk_write_time,
+    b.temp_blk_read_time,
+    b.temp_blk_write_time,
+    b.wal_fpi,
+    b.wal_bytes,
+    b.total_plan_time,
+    ltrim(regexp_replace(b.query, E'[ \\t\\n\\r]+', ' ', 'g')) AS tag_query
+FROM (
+    SELECT
+        *
+    FROM (
+        SELECT
+            *
+        FROM
+            q_data
+        WHERE
+            total_time > 0
+        ORDER BY
+            total_time DESC
+        LIMIT 100) a
+UNION
+SELECT
+    *
+FROM (
+    SELECT
+        *
+    FROM
+        q_data
+    ORDER BY
+        calls DESC
+    LIMIT 100) a
+UNION
+SELECT
+    *
+FROM (
+    SELECT
+        *
+    FROM
+        q_data
+    WHERE
+        shared_blks_read > 0
+    ORDER BY
+        shared_blks_read DESC
+    LIMIT 100) a
+UNION
+SELECT
+    *
+FROM (
+    SELECT
+        *
+    FROM
+        q_data
+    WHERE
+        shared_blks_written > 0
+    ORDER BY
+        shared_blks_written DESC
+    LIMIT 100) a
+UNION
+SELECT
+    *
+FROM (
+    SELECT
+        *
+    FROM
+        q_data
+    WHERE
+        temp_blks_read > 0
+    ORDER BY
+        temp_blks_read DESC
+    LIMIT 100) a
+UNION
+SELECT
+    *
+FROM (
+    SELECT
+        *
+    FROM
+        q_data
+    WHERE
+        temp_blks_written > 0
+    ORDER BY
+        temp_blks_written DESC
+    LIMIT 100) a) b;

--- a/pgwatch2/metrics/stat_statements/17/metric_su.sql
+++ b/pgwatch2/metrics/stat_statements/17/metric_su.sql
@@ -1,0 +1,145 @@
+WITH /* pgwatch2_generated */ q_data AS (
+    SELECT
+        queryid::text AS tag_queryid,
+        /*
+         NB! if security conscious about exposing query texts replace the below expression with a dash ('-') OR
+         use the stat_statements_no_query_text metric instead, created specifically for this use case.
+         */
+        array_to_string(array_agg(DISTINCT quote_ident(pg_get_userbyid(userid))), ',') AS users,
+        sum(s.calls)::int8 AS calls,
+        round(sum(s.total_exec_time)::numeric, 3)::double precision AS total_time,
+        sum(shared_blks_hit)::int8 AS shared_blks_hit,
+        sum(shared_blks_read)::int8 AS shared_blks_read,
+        sum(shared_blks_written)::int8 AS shared_blks_written,
+        sum(shared_blks_dirtied)::int8 AS shared_blks_dirtied,
+        sum(temp_blks_read)::int8 AS temp_blks_read,
+        sum(temp_blks_written)::int8 AS temp_blks_written,
+        round((sum(shared_blk_read_time) + sum(local_blk_read_time))::numeric, 3)::double precision AS blk_read_time,
+        round((sum(shared_blk_write_time) + sum(local_blk_write_time))::numeric, 3)::double precision AS blk_write_time,
+        round(sum(temp_blk_read_time)::numeric, 3)::double precision AS temp_blk_read_time,
+        round(sum(temp_blk_write_time)::numeric, 3)::double precision AS temp_blk_write_time,
+        sum(wal_fpi)::int8 AS wal_fpi,
+        sum(wal_bytes)::int8 AS wal_bytes,
+        round(sum(s.total_plan_time)::numeric, 3)::double precision AS total_plan_time,
+        max(query::varchar(8000)) AS query
+    FROM
+        pg_stat_statements s
+    WHERE
+        calls > 5
+        AND total_exec_time > 5
+        AND dbid = (
+            SELECT
+                oid
+            FROM
+                pg_database
+            WHERE
+                datname = current_database())
+            AND NOT upper(s.query::varchar(50))
+            LIKE ANY (ARRAY['DEALLOCATE%',
+                'SET %',
+                'RESET %',
+                'BEGIN%',
+                'BEGIN;',
+                'COMMIT%',
+                'END%',
+                'ROLLBACK%',
+                'SHOW%'])
+        GROUP BY
+            queryid
+)
+SELECT
+    (EXTRACT(epoch FROM now()) * 1e9)::int8 AS epoch_ns,
+    b.tag_queryid,
+    b.users,
+    b.calls,
+    b.total_time,
+    b.shared_blks_hit,
+    b.shared_blks_read,
+    b.shared_blks_written,
+    b.shared_blks_dirtied,
+    b.temp_blks_read,
+    b.temp_blks_written,
+    b.blk_read_time,
+    b.blk_write_time,
+    b.temp_blk_read_time,
+    b.temp_blk_write_time,
+    b.wal_fpi,
+    b.wal_bytes,
+    b.total_plan_time,
+    ltrim(regexp_replace(b.query, E'[ \\t\\n\\r]+', ' ', 'g')) AS tag_query
+FROM (
+    SELECT
+        *
+    FROM (
+        SELECT
+            *
+        FROM
+            q_data
+        WHERE
+            total_time > 0
+        ORDER BY
+            total_time DESC
+        LIMIT 100) a
+UNION
+SELECT
+    *
+FROM (
+    SELECT
+        *
+    FROM
+        q_data
+    ORDER BY
+        calls DESC
+    LIMIT 100) a
+UNION
+SELECT
+    *
+FROM (
+    SELECT
+        *
+    FROM
+        q_data
+    WHERE
+        shared_blks_read > 0
+    ORDER BY
+        shared_blks_read DESC
+    LIMIT 100) a
+UNION
+SELECT
+    *
+FROM (
+    SELECT
+        *
+    FROM
+        q_data
+    WHERE
+        shared_blks_written > 0
+    ORDER BY
+        shared_blks_written DESC
+    LIMIT 100) a
+UNION
+SELECT
+    *
+FROM (
+    SELECT
+        *
+    FROM
+        q_data
+    WHERE
+        temp_blks_read > 0
+    ORDER BY
+        temp_blks_read DESC
+    LIMIT 100) a
+UNION
+SELECT
+    *
+FROM (
+    SELECT
+        *
+    FROM
+        q_data
+    WHERE
+        temp_blks_written > 0
+    ORDER BY
+        temp_blks_written DESC
+    LIMIT 100) a) b;

--- a/pgwatch2/metrics/stat_statements_no_query_text/17/metric.sql
+++ b/pgwatch2/metrics/stat_statements_no_query_text/17/metric.sql
@@ -1,0 +1,101 @@
+with q_data as (
+  select
+    (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+    '-' as tag_query,
+    queryid::text as tag_queryid,
+    array_to_string(array_agg(distinct quote_ident(pg_get_userbyid(userid))), ',') as users,
+    sum(s.calls)::int8 as calls,
+    round(sum(s.total_exec_time)::numeric, 3)::double precision as total_time,
+    sum(shared_blks_hit)::int8 as shared_blks_hit,
+    sum(shared_blks_read)::int8 as shared_blks_read,
+    sum(shared_blks_written)::int8 as shared_blks_written,
+    sum(shared_blks_dirtied)::int8 as shared_blks_dirtied,
+    sum(temp_blks_read)::int8 as temp_blks_read,
+    sum(temp_blks_written)::int8 as temp_blks_written,
+    round((sum(shared_blk_read_time) + sum(local_blk_read_time))::numeric, 3)::double precision AS blk_read_time,
+    round((sum(shared_blk_write_time) + sum(local_blk_write_time))::numeric, 3)::double precision AS blk_write_time,
+    round(sum(temp_blk_read_time)::numeric, 3)::double precision as temp_blk_read_time,
+    round(sum(temp_blk_write_time)::numeric, 3)::double precision as temp_blk_write_time,
+    sum(wal_fpi)::int8 as wal_fpi,
+    sum(wal_bytes)::int8 as wal_bytes,
+    round(sum(s.total_plan_time)::numeric, 3)::double precision as total_plan_time
+  from
+    get_stat_statements() s
+  where
+    calls > 5
+    and total_exec_time > 0
+    and dbid = (select oid from pg_database where datname = current_database())
+    and not upper(s.query) like any (array['DEALLOCATE%', 'SET %', 'RESET %', 'BEGIN%', 'BEGIN;',
+      'COMMIT%', 'END%', 'ROLLBACK%', 'SHOW%'])
+  group by
+    queryid
+)
+select * from (
+  select
+    *
+  from
+    q_data
+  where
+    total_time > 0
+  order by
+    total_time desc
+  limit 100
+) a
+union
+select * from (
+  select
+    *
+  from
+    q_data
+  order by
+    calls desc
+  limit 100
+) a
+union
+select * from (
+  select
+    *
+  from
+    q_data
+  where
+    shared_blks_read > 0
+  order by
+    shared_blks_read desc
+  limit 100
+) a
+union
+select * from (
+  select
+    *
+  from
+    q_data
+  where
+    shared_blks_written > 0
+  order by
+    shared_blks_written desc
+  limit 100
+) a
+union
+select * from (
+  select
+    *
+  from
+    q_data
+  where
+    temp_blks_read > 0
+  order by
+    temp_blks_read desc
+  limit 100
+) a
+union
+select * from (
+  select
+    *
+  from
+    q_data
+  where
+    temp_blks_written > 0
+  order by
+    temp_blks_written desc
+  limit 100
+) a;

--- a/pgwatch2/metrics/stat_statements_no_query_text/17/metric_su.sql
+++ b/pgwatch2/metrics/stat_statements_no_query_text/17/metric_su.sql
@@ -1,0 +1,101 @@
+with q_data as (
+  select
+    (extract(epoch from now()) * 1e9)::int8 as epoch_ns,
+    '-' as tag_query,
+    queryid::text as tag_queryid,
+    array_to_string(array_agg(distinct quote_ident(pg_get_userbyid(userid))), ',') as users,
+    sum(s.calls)::int8 as calls,
+    round(sum(s.total_exec_time)::numeric, 3)::double precision as total_time,
+    sum(shared_blks_hit)::int8 as shared_blks_hit,
+    sum(shared_blks_read)::int8 as shared_blks_read,
+    sum(shared_blks_written)::int8 as shared_blks_written,
+    sum(shared_blks_dirtied)::int8 as shared_blks_dirtied,
+    sum(temp_blks_read)::int8 as temp_blks_read,
+    sum(temp_blks_written)::int8 as temp_blks_written,
+    round((sum(shared_blk_read_time) + sum(local_blk_read_time))::numeric, 3)::double precision AS blk_read_time,
+    round((sum(shared_blk_write_time) + sum(local_blk_write_time))::numeric, 3)::double precision AS blk_write_time,
+    round(sum(temp_blk_read_time)::numeric, 3)::double precision as temp_blk_read_time,
+    round(sum(temp_blk_write_time)::numeric, 3)::double precision as temp_blk_write_time,
+    sum(wal_fpi) as wal_fpi,
+    sum(wal_bytes) as wal_bytes,
+    round(sum(s.total_plan_time)::numeric, 3)::double precision as total_plan_time
+  from
+    pg_stat_statements s
+  where
+    calls > 5
+    and total_exec_time > 0
+    and dbid = (select oid from pg_database where datname = current_database())
+    and not upper(s.query) like any (array['DEALLOCATE%', 'SET %', 'RESET %', 'BEGIN%', 'BEGIN;',
+      'COMMIT%', 'END%', 'ROLLBACK%', 'SHOW%'])
+  group by
+    queryid
+)
+select * from (
+  select
+    *
+  from
+    q_data
+  where
+    total_time > 0
+  order by
+    total_time desc
+  limit 100
+) a
+union
+select * from (
+  select
+    *
+  from
+    q_data
+  order by
+    calls desc
+  limit 100
+) a
+union
+select * from (
+  select
+    *
+  from
+    q_data
+  where
+    shared_blks_read > 0
+  order by
+    shared_blks_read desc
+  limit 100
+) a
+union
+select * from (
+  select
+    *
+  from
+    q_data
+  where
+    shared_blks_written > 0
+  order by
+    shared_blks_written desc
+  limit 100
+) a
+union
+select * from (
+  select
+    *
+  from
+    q_data
+  where
+    temp_blks_read > 0
+  order by
+    temp_blks_read desc
+  limit 100
+) a
+union
+select * from (
+  select
+    *
+  from
+    q_data
+  where
+    temp_blks_written > 0
+  order by
+    temp_blks_written desc
+  limit 100
+) a;


### PR DESCRIPTION
Avoids errors on collecting from v17. The v17 release gets a bit messy though sadly, as two views have been altered in a
non-backwards-compatible way - pg_stat_bgwriter and pg_stat_statements.

For pg_stat_bgwriter a split into two monitored views pg_stat_bgwriter / pg_stat_checkpointer is unavoidable I guess as they now get different reset stats...but for pg_stat_statements I think is ok to hide the split of blk_read_time to shared_blk_read_time and local_blk_read_time as it's all slow disk access anyways. This would allow not to change a bunch of Grafana dashboards.

Another side-effect of adding the new "checkpointer" metric to preset configs where "bgwriter" exists is that there will be an info-level notice emitted 1x per hour for <17 Postgres versions looking like - Failed to get SQL for metric 'checkpointer'. But this is better I guess than having new preset_configs for v17+. One could also downgrade the message to debug level actually